### PR TITLE
Remove AppCache

### DIFF
--- a/src/AppCache.php
+++ b/src/AppCache.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace eLife\Journal;
-
-use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
-
-class AppCache extends HttpCache
-{
-}

--- a/web/app.php
+++ b/web/app.php
@@ -1,6 +1,5 @@
 <?php
 
-use eLife\Journal\AppCache;
 use eLife\Journal\AppKernel;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -9,7 +8,6 @@ require_once __DIR__.'/../var/bootstrap.php.cache';
 
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();
-$kernel = new AppCache($kernel);
 
 Request::enableHttpMethodParameterOverride();
 


### PR DESCRIPTION
In production we'll use a proper cache (eg Varnish, CloudFront), so we don't need `AppCache`.
