### PR TITLE
Simplifying build, and showing proofreader's failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,13 +6,7 @@ elifePipeline {
     stage 'Project tests'
     lock('journal--ci') {
         builderDeployRevision 'journal--ci', commit
-        builderProjectTests 'journal--ci', '/srv/journal'
-        def phpunitTestArtifact = "${env.BUILD_TAG}.phpunit.xml"
-        builderTestArtifact phpunitTestArtifact, 'journal--ci', '/srv/journal/build/phpunit.xml'
-        def behatTestArtifact = "${env.BUILD_TAG}.behat.xml"
-        builderTestArtifact behatTestArtifact, 'journal--ci', '/srv/journal/build/behat.xml'
-        elifeVerifyJunitXml phpunitTestArtifact
-        elifeVerifyJunitXml behatTestArtifact
+        builderProjectTests 'journal--ci', '/srv/journal', ['/srv/journal/build/phpunit.xml', '/srv/journal/build/behat.xml']
     }
 
     elifeMainlineOnly {

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+rm -f build/*.xml
 proofreader app/ bin/ features/ src/ test/ web/
 vendor/bin/phpunit --log-junit build/phpunit.xml
 vendor/bin/behat --tags '~wip' --format junit --format pretty


### PR DESCRIPTION
The retrieval of the XML artifacts is always attempted, but does not cause an error if they are missing like in the case of proofreader.
The original error of `project_tests.sh` is re-raised, see https://github.com/elifesciences/elife-jenkins-workflow-libs/blob/master/vars/builderProjectTests.groovy
