### PR TITLE
Add assetsPath as a Mustache global variable

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,6 +3,8 @@ imports:
   - resource: services.yml
 
 bobthecow_mustache:
+    globals:
+        assetsPath: '@elife.patterns.mustache.helpers.assets_path'
     loader_id: elife.patterns.mustache.loader.puli
     partials_loader_id: elife.patterns.mustache.loader.filesystem
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -94,13 +94,11 @@ services:
         arguments:
           - '@elife.api_client.subjects'
           - '@router'
-          - '@puli.url_generator'
 
     elife.journal.view_model.factory.listing_teaser:
         class: eLife\Journal\ViewModel\ListingTeaserFactory
         arguments:
           - '@router'
-          - '@puli.url_generator'
           - '@elife.api_client.subjects'
 
     elife.journal.view_model.factory.listing_teaser_secondary:
@@ -130,6 +128,12 @@ services:
         decorates: elife.patterns.pattern_renderer
         arguments:
           - '@elife.patterns.pattern_renderer.asset_recording.inner'
+
+    elife.patterns.mustache.helpers.assets_path:
+        class: eLife\Journal\Mustache\DynamicValueHelper
+        public: false
+        arguments:
+          - '@=parse_url(service("puli.url_generator").generateUrl("/elife/patterns/assets"), constant("PHP_URL_PATH"))'
 
     elife.patterns.mustache.loader.puli:
         class: eLife\Patterns\Mustache\PuliLoader

--- a/composer.lock
+++ b/composer.lock
@@ -728,12 +728,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "cd45d97e2b4f23f1e39d7e1c9793fc25222f9346"
+                "reference": "ed2c656739ae38a8b6f8e6d5549de1095e762512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/cd45d97e2b4f23f1e39d7e1c9793fc25222f9346",
-                "reference": "cd45d97e2b4f23f1e39d7e1c9793fc25222f9346",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/ed2c656739ae38a8b6f8e6d5549de1095e762512",
+                "reference": "ed2c656739ae38a8b6f8e6d5549de1095e762512",
                 "shasum": ""
             },
             "require": {
@@ -776,7 +776,7 @@
                 "source": "https://github.com/elifesciences/patterns-php/tree/master",
                 "issues": "https://github.com/elifesciences/patterns-php/issues"
             },
-            "time": "2016-09-08 09:21:49"
+            "time": "2016-09-08 12:45:43"
         },
         {
             "name": "guzzlehttp/guzzle",

--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -4,6 +4,7 @@ namespace eLife\Journal;
 
 use Bobthecow\Bundle\MustacheBundle\BobthecowMustacheBundle;
 use Csa\Bundle\GuzzleBundle\CsaGuzzleBundle;
+use eLife\Journal\Expression\ParseUrlFunctionProvider;
 use Puli\SymfonyBundle\PuliBundle;
 use Sensio\Bundle\DistributionBundle\SensioDistributionBundle;
 use Symfony\Bundle\DebugBundle\DebugBundle;
@@ -12,6 +13,7 @@ use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -68,5 +70,14 @@ class AppKernel extends Kernel
         $response = $this->handle($request);
         $response->send();
         $this->terminate($request, $response);
+    }
+
+    protected function buildContainer() : ContainerBuilder
+    {
+        $builder = parent::buildContainer();
+
+        $builder->addExpressionLanguageProvider(new ParseUrlFunctionProvider());
+
+        return $builder;
     }
 }

--- a/src/Expression/ParseUrlFunctionProvider.php
+++ b/src/Expression/ParseUrlFunctionProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace eLife\Journal\Expression;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+
+final class ParseUrlFunctionProvider implements ExpressionFunctionProviderInterface
+{
+    public function getFunctions() : array
+    {
+        return [
+            new ExpressionFunction(
+                'parse_url',
+                function ($string, $component = '-1') {
+                    return sprintf('parse_url(%s, %s)', $string, $component);
+                },
+                function ($arguments, $string, $component = '-1') {
+                    return parse_url($string, $component);
+                }
+            ),
+        ];
+    }
+}

--- a/src/Mustache/DynamicValueHelper.php
+++ b/src/Mustache/DynamicValueHelper.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace eLife\Journal\Mustache;
+
+final class DynamicValueHelper
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function __invoke()
+    {
+        return $this->value;
+    }
+}

--- a/src/ViewModel/FooterFactory.php
+++ b/src/ViewModel/FooterFactory.php
@@ -10,23 +10,19 @@ use eLife\Patterns\ViewModel\Link;
 use eLife\Patterns\ViewModel\MainMenu;
 use eLife\Patterns\ViewModel\MainMenuLink;
 use GuzzleHttp\Promise\PromiseInterface;
-use Puli\UrlGenerator\Api\UrlGenerator as PuliUrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class FooterFactory
 {
     private $subjectsClient;
     private $urlGenerator;
-    private $puliUrlGenerator;
 
     public function __construct(
         SubjectsClient $subjectsClient,
-        UrlGeneratorInterface $urlGenerator,
-        PuliUrlGenerator $puliUrlGenerator
+        UrlGeneratorInterface $urlGenerator
     ) {
         $this->subjectsClient = $subjectsClient;
         $this->urlGenerator = $urlGenerator;
-        $this->puliUrlGenerator = $puliUrlGenerator;
     }
 
     public function createFooter() : PromiseInterface
@@ -43,7 +39,6 @@ final class FooterFactory
                 }
 
                 return new Footer(
-                    parse_url($this->puliUrlGenerator->generateUrl('/elife/patterns/assets'), PHP_URL_PATH),
                     new MainMenu([
                         new MainMenuLink('Subjects', $subjects),
                         new MainMenuLink('eLife', [

--- a/src/ViewModel/ListingTeaserFactory.php
+++ b/src/ViewModel/ListingTeaserFactory.php
@@ -14,8 +14,6 @@ use eLife\Patterns\ViewModel\TeaserFooter;
 use eLife\Patterns\ViewModel\TeaserImage;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Uri;
-use Puli\UrlGenerator\Api\UrlGenerator as PuliUrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use function GuzzleHttp\Promise\all;
 
@@ -24,16 +22,13 @@ final class ListingTeaserFactory
     use CreatesTeasers;
 
     private $urlGenerator;
-    private $puliUrlGenerator;
     private $subjects;
 
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
-        PuliUrlGenerator $puliUrlGenerator,
         SubjectsClient $subjects
     ) {
         $this->urlGenerator = $urlGenerator;
-        $this->puliUrlGenerator = $puliUrlGenerator;
         $this->subjects = $subjects;
     }
 
@@ -85,8 +80,7 @@ final class ListingTeaserFactory
                             ucfirst(str_replace('-', ' ', $article['type'])),
                             new Date(DateTimeImmutable::createFromFormat(DATE_ATOM, $article['published']))
                         ),
-                        'vor' === $article['status'],
-                        (new Uri($this->puliUrlGenerator->generateUrl('/elife/patterns/assets')))->withQuery('')
+                        'vor' === $article['status']
                     )
                 );
             })

--- a/test/Expression/ParseUrlFunctionProviderTest.php
+++ b/test/Expression/ParseUrlFunctionProviderTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace test\eLife\Journal\Expression;
+
+use eLife\Journal\Expression\ParseUrlFunctionProvider;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+final class ParseUrlFunctionProviderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_parses_urls()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+
+        $expressionLanguage->registerProvider(new ParseUrlFunctionProvider());
+
+        $this->assertSame(
+            parse_url('http://www.example.com/foo'),
+            $expressionLanguage->evaluate('parse_url("http://www.example.com/foo")')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_parses_url_components()
+    {
+        $expressionLanguage = new ExpressionLanguage();
+
+        $expressionLanguage->registerProvider(new ParseUrlFunctionProvider());
+
+        $this->assertSame(
+            '/foo',
+            $expressionLanguage->evaluate('parse_url("http://www.example.com/foo", constant("PHP_URL_PATH"))')
+        );
+    }
+}

--- a/test/Mustache/DynamicValueHelperTest.php
+++ b/test/Mustache/DynamicValueHelperTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace test\eLife\Journal\Mustache;
+
+use eLife\Journal\Mustache\DynamicValueHelper;
+use PHPUnit_Framework_TestCase;
+
+final class DynamicValueHelperTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_the_value()
+    {
+        $helper = new DynamicValueHelper('foo');
+
+        $this->assertSame('foo', $helper());
+    }
+}


### PR DESCRIPTION
`DynamicValueHelper` is a bit of a hack as the Mustache bundle doesn't recognise expressions as helpers (only services and parameters).

Using `parse_url()` in the expression is also a bit of a hack due to https://github.com/puli/issues/issues/203.
