### PR TITLE
Ignore HTTPS when testing

### DIFF
--- a/app/config/services_test.yml
+++ b/app/config/services_test.yml
@@ -7,6 +7,13 @@ services:
           - '@elife.api_validator.schema_finder'
           - '@elife.api_validator.validator.json_decoder'
 
+    elife.api_validator.validator.fake_https:
+        class: eLife\ApiValidator\MessageValidator\FakeHttpsMessageValidator
+        decorates: elife.api_validator.validator
+        arguments:
+          - '@elife.api_validator.validator.fake_https.inner'
+          - '@elife.api_validator.validator.json_decoder'
+
     elife.api_validator.validator.json_decoder:
         class: Webmozart\Json\JsonDecoder
         public: false

--- a/composer.lock
+++ b/composer.lock
@@ -3302,12 +3302,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-validator-php.git",
-                "reference": "99b246203d6f010d10439ad65b93b18ab6ccc0d4"
+                "reference": "18ba36fa07b830596c78b740d6e9d6ef90e65bd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-validator-php/zipball/99b246203d6f010d10439ad65b93b18ab6ccc0d4",
-                "reference": "99b246203d6f010d10439ad65b93b18ab6ccc0d4",
+                "url": "https://api.github.com/repos/elifesciences/api-validator-php/zipball/18ba36fa07b830596c78b740d6e9d6ef90e65bd3",
+                "reference": "18ba36fa07b830596c78b740d6e9d6ef90e65bd3",
                 "shasum": ""
             },
             "require": {
@@ -3341,7 +3341,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API validator",
-            "time": "2016-08-15 11:58:26"
+            "time": "2016-09-13 08:27:27"
         },
         {
             "name": "jarnaiz/behat-junit-formatter",


### PR DESCRIPTION
The eLife API requires references to embeddable assets (eg images) to be HTTPS, but when testing we may not have it available (especially locally). This bypasses that check.
