### PR TITLE
Configuring a JSON logger

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -11,9 +11,19 @@ monolog:
             type: console
         main:
             action_level: error
-            handler: nested
+            handler: composite
             type: fingers_crossed
-        nested:
+        composite:
+            type: group
+            members:
+                - text
+                - json
+        text:
             type: stream
-            path: '%kernel.logs_dir%/%kernel.environment%.log'
+            path: '%kernel.logs_dir%/%kernel.environment%.txt.log'
             level: debug
+        json:
+            type: stream
+            path: '%kernel.logs_dir%/%kernel.environment%.json.log'
+            level: debug
+            formatter: monolog.formatter.json


### PR DESCRIPTION
This adds a `.json.log` file in the `end2end` and `prod` environments, so that we can use syslog-ng to send it to Loggly
