### PR TITLE
Allow for arbitrary long article ids

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -32,7 +32,6 @@ article:
          _controller: AppBundle:Articles:latestVersion
     requirements:
         volume: '[1-9][0-9]*'
-        id: '[0-9]{5}'
 
 collection:
     path: /collections/{id}


### PR DESCRIPTION
This is useful for testing with ids like `1855971589`. Also `volume` already allows for arbitrarily long numbers
