### PR TITLE
Let generic exceptions in calling API bubble up

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -45,6 +45,7 @@ final class ArticlesController extends Controller
                 if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
                     throw new NotFoundHttpException('Article not found', $e);
                 }
+                throw $e;
             })
             ->then(function (Result $result) use ($volume) {
                 if ($volume !== $result['volume']) {


### PR DESCRIPTION
Without rethrowing, then() is also called afterwards producing this unclear error:

```
[2016-10-24 12:03:33] request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 1 passed to eLife\Journal\Controller\ArticlesController::eLife\Journal\Controller\{closure}() must be an instance of eLife\ApiClient\Result, null given, called in /srv/journal/vendor/guzzlehttp/promises/src/Promise.php on line 203" at /srv/journal/src/Controller/ArticlesController.php line 49 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowable Error(code: 0): Type error: Argument 1 passed to eLife\\Journal\\Controller\\ArticlesController::eLife\\Journal\\Controller\\{closure}() must be an instance of eLife\\Api Client\\Result, null given, called in /srv/journal/vendor/guzzlehttp/promises/src/Promise.php on line 203 at /srv/journal/src/Controller/ArticlesController.php:49)"} []
```

When rethrowing, the original exception is logged instead (in this case
a problem with Accept headers).

This is a temporary patch as this will be replaced by the SDK code.
