### PR TITLE
Catch API exceptions at a higher level

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -62,6 +62,11 @@ services:
         arguments:
           - '@elife.api_client.client'
 
+    elife.journal.listener.api_bad_response:
+        class: eLife\Journal\EventListener\ApiBadResponseSubscriber
+        tags:
+          - name: kernel.event_subscriber
+
     elife.journal.templating.promise_aware:
         class: eLife\Journal\Templating\PromiseAwareEngine
         decorates: templating

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\ArticlesClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel;
@@ -25,7 +24,6 @@ use eLife\Patterns\ViewModel\SubjectList;
 use eLife\Patterns\ViewModel\ViewSelector;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 use function GuzzleHttp\Promise\all;
 
 final class ArticlesController extends Controller
@@ -41,12 +39,6 @@ final class ArticlesController extends Controller
                     new MediaType(ArticlesClient::TYPE_ARTICLE_VOR, 1),
                 ],
             ], $id)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Article not found', $e);
-                }
-                throw $e;
-            })
             ->then(function (Result $result) use ($volume) {
                 if ($volume !== $result['volume']) {
                     throw new NotFoundHttpException('Incorrect volume');

--- a/src/Controller/CollectionsController.php
+++ b/src/Controller/CollectionsController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\CollectionsClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\BackgroundImage;
@@ -16,8 +15,6 @@ use eLife\Patterns\ViewModel\Link;
 use eLife\Patterns\ViewModel\ListHeading;
 use eLife\Patterns\ViewModel\Meta;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class CollectionsController extends Controller
 {
@@ -56,12 +53,7 @@ final class CollectionsController extends Controller
         $arguments = $this->defaultPageArguments();
 
         $arguments['collection'] = $this->get('elife.api_client.collections')
-            ->getCollection(['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)], $id)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Collection not found', $e);
-                }
-            });
+            ->getCollection(['Accept' => new MediaType(CollectionsClient::TYPE_COLLECTION, 1)], $id);
 
         $arguments['contentHeader'] = $arguments['collection']
             ->then(function (Result $collection) {

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -3,15 +3,12 @@
 namespace eLife\Journal\Controller;
 
 use eLife\ApiClient\ApiClient\EventsClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\ContentHeaderNonArticle;
 use eLife\Patterns\ViewModel\LeadPara;
 use eLife\Patterns\ViewModel\LeadParas;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class EventsController extends Controller
 {
@@ -49,12 +46,7 @@ final class EventsController extends Controller
         $arguments = $this->defaultPageArguments();
 
         $arguments['event'] = $this->get('elife.api_client.events')
-            ->getEvent(['Accept' => new MediaType(EventsClient::TYPE_EVENT, 1)], $id)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Event not found', $e);
-                }
-            });
+            ->getEvent(['Accept' => new MediaType(EventsClient::TYPE_EVENT, 1)], $id);
 
         $arguments['contentHeader'] = $arguments['event']
             ->then(function (Result $event) {

--- a/src/Controller/InsideElifeController.php
+++ b/src/Controller/InsideElifeController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\BlogClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\ContentHeaderNonArticle;
@@ -15,8 +14,6 @@ use eLife\Patterns\ViewModel\Link;
 use eLife\Patterns\ViewModel\ListHeading;
 use eLife\Patterns\ViewModel\Meta;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class InsideElifeController extends Controller
 {
@@ -45,8 +42,7 @@ final class InsideElifeController extends Controller
 
                 return $this->get('elife.journal.view_model.factory.listing_teaser')
                     ->forItems($items, $arguments['latestHeading']['heading']);
-            })
-        ;
+            });
 
         return new Response($this->get('templating')->render('::inside-elife.html.twig', $arguments));
     }
@@ -56,14 +52,7 @@ final class InsideElifeController extends Controller
         $arguments = $this->defaultPageArguments();
 
         $arguments['article'] = $this->get('elife.api_client.blog')
-            ->getArticle(['Accept' => new MediaType(BlogClient::TYPE_BLOG_ARTICLE, 1)], $id)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Article not found', $e);
-                }
-
-                throw $e;
-            });
+            ->getArticle(['Accept' => new MediaType(BlogClient::TYPE_BLOG_ARTICLE, 1)], $id);
 
         $arguments['contentHeader'] = $arguments['article']
             ->then(function (Result $article) {

--- a/src/Controller/InterviewsController.php
+++ b/src/Controller/InterviewsController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\InterviewsClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\ContentHeaderNonArticle;
@@ -13,8 +12,6 @@ use eLife\Patterns\ViewModel\LeadPara;
 use eLife\Patterns\ViewModel\LeadParas;
 use eLife\Patterns\ViewModel\Meta;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class InterviewsController extends Controller
 {
@@ -23,12 +20,7 @@ final class InterviewsController extends Controller
         $arguments = $this->defaultPageArguments();
 
         $arguments['interview'] = $this->get('elife.api_client.interviews')
-            ->getInterview(['Accept' => new MediaType(InterviewsClient::TYPE_INTERVIEW, 1)], $id)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Interview not found', $e);
-                }
-            });
+            ->getInterview(['Accept' => new MediaType(InterviewsClient::TYPE_INTERVIEW, 1)], $id);
 
         $arguments['contentHeader'] = $arguments['interview']
             ->then(function (Result $interview) {

--- a/src/Controller/LabsController.php
+++ b/src/Controller/LabsController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\LabsClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\BackgroundImage;
@@ -15,8 +14,6 @@ use eLife\Patterns\ViewModel\LeadPara;
 use eLife\Patterns\ViewModel\LeadParas;
 use eLife\Patterns\ViewModel\Meta;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class LabsController extends Controller
 {
@@ -56,12 +53,7 @@ developed further to become features on the eLife platform.'),
         $arguments = $this->defaultPageArguments();
 
         $arguments['experiment'] = $this->get('elife.api_client.labs')
-            ->getExperiment(['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT, 1)], $number)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Experiment not found', $e);
-                }
-            });
+            ->getExperiment(['Accept' => new MediaType(LabsClient::TYPE_EXPERIMENT, 1)], $number);
 
         $arguments['contentHeader'] = $arguments['experiment']
             ->then(function (Result $experiment) {

--- a/src/Controller/PodcastController.php
+++ b/src/Controller/PodcastController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use DateTimeImmutable;
 use eLife\ApiClient\ApiClient\PodcastClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\AudioPlayer;
@@ -23,8 +22,6 @@ use eLife\Patterns\ViewModel\Meta;
 use eLife\Patterns\ViewModel\Picture;
 use eLife\Patterns\ViewModel\PodcastDownload;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class PodcastController extends Controller
 {
@@ -58,12 +55,7 @@ final class PodcastController extends Controller
         $arguments = $this->defaultPageArguments();
 
         $arguments['episode'] = $this->get('elife.api_client.podcast')
-            ->getEpisode(['Accept' => new MediaType(PodcastClient::TYPE_PODCAST_EPISODE, 1)], $number)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Episode not found', $e);
-                }
-            });
+            ->getEpisode(['Accept' => new MediaType(PodcastClient::TYPE_PODCAST_EPISODE, 1)], $number);
 
         $arguments['contentHeader'] = $arguments['episode']
             ->then(function (Result $episode) {

--- a/src/Controller/SubjectsController.php
+++ b/src/Controller/SubjectsController.php
@@ -4,7 +4,6 @@ namespace eLife\Journal\Controller;
 
 use eLife\ApiClient\ApiClient\SearchClient;
 use eLife\ApiClient\ApiClient\SubjectsClient;
-use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\MediaType;
 use eLife\ApiClient\Result;
 use eLife\Patterns\ViewModel\BackgroundImage;
@@ -16,8 +15,6 @@ use eLife\Patterns\ViewModel\LeadParas;
 use eLife\Patterns\ViewModel\Link;
 use eLife\Patterns\ViewModel\ListHeading;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Throwable;
 
 final class SubjectsController extends Controller
 {
@@ -60,12 +57,7 @@ final class SubjectsController extends Controller
         $arguments = $this->defaultPageArguments();
 
         $arguments['subject'] = $this->get('elife.api_client.subjects')
-            ->getSubject(['Accept' => new MediaType(SubjectsClient::TYPE_SUBJECT, 1)], $id)
-            ->otherwise(function (Throwable $e) {
-                if ($e instanceof BadResponse && 404 === $e->getResponse()->getStatusCode()) {
-                    throw new NotFoundHttpException('Subject not found', $e);
-                }
-            });
+            ->getSubject(['Accept' => new MediaType(SubjectsClient::TYPE_SUBJECT, 1)], $id);
 
         $arguments['contentHeader'] = $arguments['subject']
             ->then(function (Result $subject) {

--- a/src/EventListener/ApiBadResponseSubscriber.php
+++ b/src/EventListener/ApiBadResponseSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace eLife\Journal\EventListener;
+
+use eLife\ApiClient\Exception\BadResponse;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ApiBadResponseSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents() : array
+    {
+        return ['kernel.exception' => 'onKernelException'];
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $exception = $event->getException();
+
+        if (false === $exception instanceof BadResponse) {
+            return;
+        }
+
+        /** @var BadResponse $exception */
+        switch ($exception->getResponse()->getStatusCode()) {
+            case Response::HTTP_GONE:
+            case Response::HTTP_NOT_FOUND:
+            case Response::HTTP_SERVICE_UNAVAILABLE:
+                $exception = new HttpException($exception->getResponse()->getStatusCode(), $exception->getMessage(), $exception);
+                break;
+        }
+
+        $event->setException($exception);
+    }
+}

--- a/test/AppKernelTestCase.php
+++ b/test/AppKernelTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace test\eLife\Journal;
+
+use eLife\Journal\AppKernel;
+
+trait AppKernelTestCase
+{
+    final protected static function getKernelClass() : string
+    {
+        return AppKernel::class;
+    }
+}

--- a/test/EventListener/ApiBadResponseSubscriberTest.php
+++ b/test/EventListener/ApiBadResponseSubscriberTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace test\eLife\Journal\EventListener;
+
+use eLife\ApiClient\Exception\ApiException;
+use eLife\ApiClient\Exception\BadResponse;
+use eLife\Journal\EventListener\ApiBadResponseSubscriber;
+use Exception;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request as HttpFoundationRequest;
+use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use test\eLife\Journal\AppKernelTestCase;
+
+final class ApiBadResponseSubscriberTest extends KernelTestCase
+{
+    use AppKernelTestCase;
+
+    /**
+     * @test
+     * @dataProvider statusCodeProvider
+     */
+    public function it_turns_exceptions_into_http_exceptions(int $statusCode)
+    {
+        $subscriber = new ApiBadResponseSubscriber();
+
+        $exception = new BadResponse('foo', new Request('GET', 'http://www.example.com/'), new Response($statusCode));
+        $event = $this->createGetResponseForExceptionEvent($exception);
+
+        $subscriber->onKernelException($event);
+
+        $this->assertInstanceOf(HttpExceptionInterface::class, $event->getException());
+        $this->assertSame($statusCode, $event->getException()->getStatusCode());
+        $this->assertSame($exception, $event->getException()->getPrevious());
+    }
+
+    public function statusCodeProvider() : array
+    {
+        return [
+            [HttpFoundationResponse::HTTP_GONE],
+            [HttpFoundationResponse::HTTP_NOT_FOUND],
+            [HttpFoundationResponse::HTTP_SERVICE_UNAVAILABLE],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider nonBadResponseExceptionProvider
+     */
+    public function it_ignores_non_bad_response_exceptions(Exception $exception)
+    {
+        $subscriber = new ApiBadResponseSubscriber();
+
+        $event = $event = $this->createGetResponseForExceptionEvent($exception);
+
+        $subscriber->onKernelException($event);
+
+        $this->assertSame($exception, $event->getException());
+    }
+
+    public function nonBadResponseExceptionProvider() : array
+    {
+        return [
+            [new Exception('foo')],
+            [new ApiException('foo')],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_exceptions_on_sub_requests()
+    {
+        $subscriber = new ApiBadResponseSubscriber();
+
+        $exception = new BadResponse('foo', new Request('GET', 'http://www.example.com/'), new Response());
+        $event = $this->createGetResponseForExceptionEvent($exception, HttpKernelInterface::SUB_REQUEST);
+
+        $subscriber->onKernelException($event);
+
+        $this->assertSame($exception, $event->getException());
+    }
+
+    private function createGetResponseForExceptionEvent(Exception $exception, int $requestType = HttpKernelInterface::MASTER_REQUEST) : GetResponseForExceptionEvent
+    {
+        return new GetResponseForExceptionEvent($this->createKernel(), new HttpFoundationRequest(), $requestType, $exception);
+    }
+}

--- a/test/WebTestCase.php
+++ b/test/WebTestCase.php
@@ -2,7 +2,6 @@
 
 namespace test\eLife\Journal;
 
-use eLife\Journal\AppKernel;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
@@ -10,10 +9,7 @@ use Symfony\Component\Filesystem\Filesystem;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
-    final protected static function getKernelClass()
-    {
-        return AppKernel::class;
-    }
+    use AppKernelTestCase;
 
     final protected static function bootKernel(array $options = [])
     {


### PR DESCRIPTION
Controllers tend to have a main API request, which govern whether the page itself renders. They might also have other requests which build less important parts of the page (eg a sidebar), which probably shouldn't cause the page to not render if they fail for some reason.

This changes exception handling for the former to a higher level, and relies on the latter being caught in the controller. It also expands the former handling so it covers 410s and 503s, not just 404s.