### PR TITLE
Avoid page range prefix when reference has a volume

### DIFF
--- a/src/ViewModel/Converter/Reference/JournalReferenceConverter.php
+++ b/src/ViewModel/Converter/Reference/JournalReferenceConverter.php
@@ -3,6 +3,7 @@
 namespace eLife\Journal\ViewModel\Converter\Reference;
 
 use eLife\ApiSdk\Model\Reference\JournalReference;
+use eLife\ApiSdk\Model\Reference\ReferencePageRange;
 use eLife\Journal\ViewModel\Converter\ViewModelConverter;
 use eLife\Patterns\ViewModel;
 
@@ -16,11 +17,16 @@ final class JournalReferenceConverter implements ViewModelConverter
     public function convert($object, string $viewModel = null, array $context = []) : ViewModel
     {
         $journal = '<i>'.implode(', ', $object->getJournal()->getName()).'</i>';
-        $journalExtra = $object->getPages()->toString();
         if ($object->getVolume()) {
-            $journalExtra = '<b>'.$object->getVolume().'</b>:'.$journalExtra;
+            $journal .= ' <b>'.$object->getVolume().'</b>:';
+            if ($object->getPages() instanceof ReferencePageRange) {
+                $journal .= $object->getPages()->getRange();
+            } else {
+                $journal .= $object->getPages()->toString();
+            }
+        } elseif ($object->getPages()) {
+            $journal .= ' '.$object->getPages()->toString();
         }
-        $journal .= ' '.$journalExtra;
 
         $origin = [
             $object->getDate()->format(),

--- a/src/ViewModel/Converter/Reference/PeriodicalReferenceConverter.php
+++ b/src/ViewModel/Converter/Reference/PeriodicalReferenceConverter.php
@@ -3,6 +3,7 @@
 namespace eLife\Journal\ViewModel\Converter\Reference;
 
 use eLife\ApiSdk\Model\Reference\PeriodicalReference;
+use eLife\ApiSdk\Model\Reference\ReferencePageRange;
 use eLife\Journal\ViewModel\Converter\ViewModelConverter;
 use eLife\Patterns\ViewModel;
 
@@ -16,11 +17,16 @@ final class PeriodicalReferenceConverter implements ViewModelConverter
     public function convert($object, string $viewModel = null, array $context = []) : ViewModel
     {
         $periodical = '<i>'.implode(', ', $object->getPeriodical()->getName()).'</i>';
-        $periodicalExtra = $object->getPages()->toString();
         if ($object->getVolume()) {
-            $periodicalExtra = '<b>'.$object->getVolume().'</b>:'.$periodicalExtra;
+            $periodical .= ' <b>'.$object->getVolume().'</b>:';
+            if ($object->getPages() instanceof ReferencePageRange) {
+                $periodical .= $object->getPages()->getRange();
+            } else {
+                $periodical .= $object->getPages()->toString();
+            }
+        } elseif ($object->getPages()) {
+            $periodical .= ' '.$object->getPages()->toString();
         }
-        $periodical .= ' '.$periodicalExtra;
 
         $origin = [
             $object->getDate()->format(),


### PR DESCRIPTION
Following https://github.com/elifesciences/api-sdk-php/pull/55 `ReferencePageRange::toString()` returns a 'p.' or 'pp.' prefix. However, when combining the page range with a volume we need to ignore the prefix (otherwise it ends up like '52:pp. 696–704').