### PR TITLE
ELPP-1823 Fix articles with only 1 section

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -313,7 +313,7 @@ final class ArticlesController extends Controller
                 $body = $sections['body'];
                 $hasFigures = $sections['hasFigures'];
 
-                if ((count($body) < 2 || false === $body[0] instanceof ArticleSection) && !$hasFigures) {
+                if ((count($body) < 3 || false === $body[0] instanceof ArticleSection) && !$hasFigures) {
                     return null;
                 }
 


### PR DESCRIPTION
#139 added an `ArticleMeta` to the `$body` of an article. This is always present.