### PR TITLE
Fix on-behalf-of author and equal contribution groups conflict

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -186,8 +186,8 @@ final class ArticlesController extends Controller
 
                         if ($personAuthors->notEmpty()) {
                             $infoSections[] = new ViewModel\AuthorsDetails(
-                                ...$personAuthors->map(function (PersonAuthor $author) use ($article) {
-                                    return $this->get('elife.journal.view_model.converter')->convert($author, null, ['article' => $article]);
+                                ...$personAuthors->map(function (PersonAuthor $author) use ($realAuthors) {
+                                    return $this->get('elife.journal.view_model.converter')->convert($author, null, ['authors' => $realAuthors]);
                                 })
                             );
                         }

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -129,6 +129,7 @@ final class ArticleControllerTest extends PageTestCase
                                     ],
                                 ],
                             ],
+                            'equalContributionGroups' => [1],
                         ],
                         [
                             'type' => 'person',
@@ -136,6 +137,7 @@ final class ArticleControllerTest extends PageTestCase
                                 'preferred' => 'Author Two',
                                 'index' => 'Author Two',
                             ],
+                            'equalContributionGroups' => [1],
                         ],
                         [
                             'type' => 'person',
@@ -171,6 +173,15 @@ final class ArticleControllerTest extends PageTestCase
                         [
                             'type' => 'on-behalf-of',
                             'onBehalfOf' => 'on behalf of Institution Four',
+                        ],
+                    ],
+                    'abstract' => [
+                        'doi' => '10.7554/eLife.09560.001',
+                        'content' => [
+                            [
+                                'type' => 'paragraph',
+                                'text' => 'Abstract text',
+                            ],
                         ],
                     ],
                     'body' => [


### PR DESCRIPTION
Having an on-behalf-of author, equal contribution groups and article sections caused a failure.