### PR TITLE
Run all end2end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,10 +11,10 @@ elifePipeline {
 
     elifeMainlineOnly {
         stage 'End2end tests'
-        elifeEnd2EndTest({
+        elifeEnd2EndTest {
             builderDeployRevision 'journal--end2end', commit
             builderSmokeTests 'journal--end2end', '/srv/journal'
-        }, 'two')
+        }
 
         stage 'Deploy on demo'
         builderDeployRevision 'journal--demo', commit


### PR DESCRIPTION
And not only the subset tagged with 'two'. Now that journal and elife 2.0 are integrated with the 1.0 projects, the end2end tests should be the same.

At the moment, the end2end tests try to load an HTML page on journal for each article being published (not checking yet for images and other media)