### PR TITLE
ELPP-2088 Add header search subject filter

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -59,6 +59,11 @@ default:
                 tags: '@podcast'
             contexts:
               - PodcastContext
+        search:
+            filters:
+                tags: '@search'
+            contexts:
+              - SearchContext
         subject:
             filters:
                 tags: '@subject'

--- a/features/bootstrap/SearchContext.php
+++ b/features/bootstrap/SearchContext.php
@@ -1,0 +1,121 @@
+<?php
+
+use Behat\Gherkin\Node\TableNode;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+final class SearchContext extends Context
+{
+    /**
+     * @Given /^I am reading an article:$/
+     */
+    public function iAmReadingAnArticle(TableNode $table)
+    {
+        $subjects = array_map(function (string $subject) {
+            return [
+                'id' => $this->createSubjectId($subject),
+                'name' => $subject,
+            ];
+        }, explode(', ', $table->getRowsHash()['Subjects']));
+
+        $this->mockApiResponse(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles/00001',
+                [
+                    'Accept' => [
+                        'application/vnd.elife.article-poa+json; version=1',
+                        'application/vnd.elife.article-vor+json; version=1',
+                    ],
+                ]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/vnd.elife.article-poa+json; version=1'],
+                json_encode([
+                    'status' => 'poa',
+                    'stage' => 'published',
+                    'id' => '00001',
+                    'version' => 1,
+                    'type' => 'research-article',
+                    'doi' => '10.7554/eLife.00001',
+                    'title' => 'Article title',
+                    'published' => '2010-01-01T00:00:00Z',
+                    'versionDate' => '2010-01-01T00:00:00Z',
+                    'statusDate' => '2010-01-01T00:00:00Z',
+                    'volume' => 1,
+                    'elocationId' => 'e00001',
+                    'copyright' => [
+                        'license' => 'CC0-1.0',
+                        'statement' => 'Copyright statement.',
+                    ],
+                    'subjects' => $subjects,
+                ])
+            )
+        );
+
+        $this->mockApiResponse(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles/00001/versions',
+                [
+                    'Accept' => [
+                        'application/vnd.elife.article-history+json; version=1',
+                    ],
+                ]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+                json_encode([
+                    'versions' => [
+                        [
+                            'status' => 'poa',
+                            'stage' => 'published',
+                            'id' => '00001',
+                            'version' => 1,
+                            'type' => 'research-article',
+                            'doi' => '10.7554/eLife.00001',
+                            'title' => 'Article title',
+                            'published' => '2010-01-01T00:00:00Z',
+                            'versionDate' => '2010-01-01T00:00:00Z',
+                            'statusDate' => '2010-01-01T00:00:00Z',
+                            'volume' => 1,
+                            'elocationId' => 'e00001',
+                            'copyright' => [
+                                'license' => 'CC0-1.0',
+                                'statement' => 'Copyright statement.',
+                            ],
+                            'subjects' => $subjects,
+                        ],
+                    ],
+                ])
+            )
+        );
+
+        $this->visitPath('/content/1/e00001');
+    }
+
+    private function createSubjectId(string $subjectName) : string
+    {
+        return md5($subjectName);
+    }
+
+    /**
+     * @When /^I click search$/
+     */
+    public function iClickSearch()
+    {
+        $this->assertSession()->elementExists('css', 'a[rel="search"]')->click();
+    }
+
+    /**
+     * @Then /^I should see the option to limit the search to \'([^\']*)\'$/
+     */
+    public function iShouldSeeTheOptionToLimitTheSearchTo(string $subject)
+    {
+        $this->spin(function () use ($subject) {
+            $this->assertSession()->fieldExists('Limit my search to '.$subject);
+        });
+    }
+}

--- a/features/search-header.feature
+++ b/features/search-header.feature
@@ -1,0 +1,14 @@
+@search
+Feature: Search from page header
+
+  Rules:
+  - If the current page has a subject, the first subject appears as a limiting option when searching on that page
+
+  Background:
+    Given I am reading an article:
+      | Subjects | Cell biology, Immunology |
+
+  @javascript
+  Scenario: Page has subjects
+    When I click search
+    Then I should see the option to limit the search to 'Cell biology'

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -427,9 +427,7 @@ final class ArticlesController extends Controller
 
     private function defaultArticleArguments(int $volume, string $id, int $version = null) : array
     {
-        $arguments = $this->defaultPageArguments();
-
-        $arguments['article'] = $this->get('elife.api_sdk.articles')
+        $article = $this->get('elife.api_sdk.articles')
             ->get($id, $version)
             ->then(function (ArticleVersion $article) use ($volume) {
                 if ($volume !== $article->getVolume()) {
@@ -438,6 +436,10 @@ final class ArticlesController extends Controller
 
                 return $article;
             });
+
+        $arguments = $this->defaultPageArguments($article);
+
+        $arguments['article'] = $article;
 
         return $arguments;
     }

--- a/src/Controller/CollectionsController.php
+++ b/src/Controller/CollectionsController.php
@@ -68,9 +68,11 @@ final class CollectionsController extends Controller
 
     public function collectionAction(string $id) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $collection = $this->get('elife.api_sdk.collections')->get($id);
 
-        $arguments['collection'] = $this->get('elife.api_sdk.collections')->get($id);
+        $arguments = $this->defaultPageArguments($collection);
+
+        $arguments['collection'] = $collection;
 
         $arguments['contentHeader'] = $arguments['collection']
             ->then($this->willConvertTo(ContentHeaderNonArticle::class));

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -2,15 +2,18 @@
 
 namespace eLife\Journal\Controller;
 
+use eLife\ApiSdk\Model\Model;
 use eLife\Journal\Helper\CanConvertContent;
 use eLife\Journal\Helper\Paginator;
 use eLife\Journal\ViewModel\Converter\ViewModelConverter;
 use eLife\Patterns\ViewModel;
 use eLife\Patterns\ViewModel\ContentHeaderSimple;
+use GuzzleHttp\Promise\PromiseInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use function GuzzleHttp\Promise\promise_for;
 
 abstract class Controller implements ContainerAwareInterface
 {
@@ -69,10 +72,12 @@ abstract class Controller implements ContainerAwareInterface
         return $response;
     }
 
-    final protected function defaultPageArguments(): array
+    final protected function defaultPageArguments(PromiseInterface $model = null): array
     {
         return [
-            'header' => $this->get('elife.journal.view_model.factory.site_header')->createSiteHeader(),
+            'header' => promise_for($model)->then(function (Model $model = null) : ViewModel\SiteHeader {
+                return $this->get('elife.journal.view_model.factory.site_header')->createSiteHeader($model);
+            }),
             'footer' => $this->get('elife.journal.view_model.factory.footer')->createFooter(),
         ];
     }

--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -70,9 +70,11 @@ final class EventsController extends Controller
 
     public function eventAction(string $id) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $event = $this->get('elife.api_sdk.events')->get($id);
 
-        $arguments['event'] = $this->get('elife.api_sdk.events')->get($id);
+        $arguments = $this->defaultPageArguments($event);
+
+        $arguments['event'] = $event;
 
         $arguments['contentHeader'] = $arguments['event']
             ->then($this->willConvertTo(ContentHeaderNonArticle::class));

--- a/src/Controller/InsideElifeController.php
+++ b/src/Controller/InsideElifeController.php
@@ -67,9 +67,11 @@ final class InsideElifeController extends Controller
 
     public function articleAction(string $id) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $article = $this->get('elife.api_sdk.blog_articles')->get($id);
 
-        $arguments['article'] = $this->get('elife.api_sdk.blog_articles')->get($id);
+        $arguments = $this->defaultPageArguments($article);
+
+        $arguments['article'] = $article;
 
         $arguments['contentHeader'] = $arguments['article']
             ->then($this->willConvertTo(ContentHeaderNonArticle::class));

--- a/src/Controller/InterviewsController.php
+++ b/src/Controller/InterviewsController.php
@@ -12,9 +12,11 @@ final class InterviewsController extends Controller
 {
     public function interviewAction(string $id) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $interview = $this->get('elife.api_sdk.interviews')->get($id);
 
-        $arguments['interview'] = $this->get('elife.api_sdk.interviews')->get($id);
+        $arguments = $this->defaultPageArguments($interview);
+
+        $arguments['interview'] = $interview;
 
         $arguments['contentHeader'] = $arguments['interview']
             ->then($this->willConvertTo(ContentHeaderNonArticle::class));

--- a/src/Controller/LabsController.php
+++ b/src/Controller/LabsController.php
@@ -79,9 +79,11 @@ developed further to become features on the eLife platform.'),
 
     public function experimentAction(int $number) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $experiment = $this->get('elife.api_sdk.labs_experiments')->get($number);
 
-        $arguments['experiment'] = $this->get('elife.api_sdk.labs_experiments')->get($number);
+        $arguments = $this->defaultPageArguments($experiment);
+
+        $arguments['experiment'] = $experiment;
 
         $arguments['contentHeader'] = $arguments['experiment']
             ->then($this->willConvertTo(ContentHeaderNonArticle::class));

--- a/src/Controller/PodcastController.php
+++ b/src/Controller/PodcastController.php
@@ -71,9 +71,11 @@ final class PodcastController extends Controller
 
     public function episodeAction(int $number) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $episode = $this->get('elife.api_sdk.podcast_episodes')->get($number);
 
-        $arguments['episode'] = $this->get('elife.api_sdk.podcast_episodes')->get($number);
+        $arguments = $this->defaultPageArguments($episode);
+
+        $arguments['episode'] = $episode;
 
         $arguments['contentHeader'] = $arguments['episode']
             ->then($this->willConvertTo(ContentHeaderNonArticle::class));

--- a/src/Controller/SubjectsController.php
+++ b/src/Controller/SubjectsController.php
@@ -58,9 +58,11 @@ final class SubjectsController extends Controller
         $page = (int) $request->query->get('page', 1);
         $perPage = 6;
 
-        $arguments = $this->defaultPageArguments();
+        $subject = $this->get('elife.api_sdk.subjects')->get($id);
 
-        $arguments['subject'] = $this->get('elife.api_sdk.subjects')->get($id);
+        $arguments = $this->defaultPageArguments($subject);
+
+        $arguments['subject'] = $subject;
 
         $latestArticles = promise_for($this->get('elife.api_sdk.search')
             ->forSubject($id)

--- a/src/ViewModel/Factory/SiteHeaderFactory.php
+++ b/src/ViewModel/Factory/SiteHeaderFactory.php
@@ -2,6 +2,9 @@
 
 namespace eLife\Journal\ViewModel\Factory;
 
+use eLife\ApiSdk\Model\HasSubjects;
+use eLife\ApiSdk\Model\Model;
+use eLife\ApiSdk\Model\Subject;
 use eLife\Patterns\ViewModel\Button;
 use eLife\Patterns\ViewModel\CompactForm;
 use eLife\Patterns\ViewModel\Form;
@@ -13,6 +16,7 @@ use eLife\Patterns\ViewModel\Picture;
 use eLife\Patterns\ViewModel\SearchBox;
 use eLife\Patterns\ViewModel\SiteHeader;
 use eLife\Patterns\ViewModel\SiteHeaderNavBar;
+use eLife\Patterns\ViewModel\SubjectFilter;
 use Puli\UrlGenerator\Api\UrlGenerator as PuliUrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -27,7 +31,7 @@ final class SiteHeaderFactory
         $this->puliUrlGenerator = $puliUrlGenerator;
     }
 
-    public function createSiteHeader() : SiteHeader
+    public function createSiteHeader(Model $model = null) : SiteHeader
     {
         $primaryLinks = SiteHeaderNavBar::primary([
             NavLinkedItem::asIcon(
@@ -80,12 +84,21 @@ final class SiteHeaderFactory
             ),
         ]);
 
+        if ($model instanceof HasSubjects) {
+            $subject = $model->getSubjects()[0];
+        } elseif ($model instanceof Subject) {
+            $subject = $model;
+        } else {
+            $subject = null;
+        }
+
         $searchBox = new SearchBox(
             new CompactForm(
                 new Form($this->urlGenerator->generate('search'), 'search', 'GET'),
                 new Input('Search by keyword or author', 'search', 'for', null, 'Search by keyword or author'),
                 'Search'
-            )
+            ),
+            $subject ? new SubjectFilter('subjects[]', $subject->getId(), $subject->getName()) : null
         );
 
         return new SiteHeader($this->urlGenerator->generate('home'), $primaryLinks, $secondaryLinks, $searchBox);


### PR DESCRIPTION
I've made it so `SiteHeaderFactory` knows about the primary model of the page (where relevant) rather than just a subject in case we need something similar in the future.