### PR TITLE
Don't try and create a carousel if the covers list is empty

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -71,9 +71,9 @@ final class HomeController extends Controller
         $arguments['carousel'] = $this->get('elife.api_sdk.covers')
             ->getCurrent()
             ->map($this->willConvertTo())
-            ->then(function (Sequence $covers) {
+            ->then(Callback::emptyOr(function (Sequence $covers) {
                 return new Carousel(...$covers);
-            })
+            }))
             ->otherwise($this->softFailure('Failed to load covers'));
 
         $arguments['leadParas'] = new LeadParas([new LeadPara('eLife is an open-access journal that publishes research in the life and biomedical sciences', 'strapline')]);


### PR DESCRIPTION
Currently an `InvalidArgumentException` is thrown when creating the `Carousel` (which is then caught, but logged). If the list is empty, we should avoid creating it.