### PR TITLE
Increase API connection timeout

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -13,13 +13,13 @@ csa_guzzle:
         elife_api:
             config:
                 base_uri: '%api_url%'
-                connect_timeout: 0.25
+                connect_timeout: 0.5
                 headers:
                     Authorization: '%api_key%'
                 timeout: 1
         file_download:
             config:
-                connect_timeout: 0.25
+                connect_timeout: 0.5
                 http_errors: false
                 stream: true
 


### PR DESCRIPTION
We're seeing sporadic failures in end2end testing due to the connection timeout. This was deliberately low to force the API to be fast, but in the meantime we should increase it slightly (500ms no longer sees failures when connecting locally, so should be enough).