### PR TITLE
ELPP-1073 Add about pages

### DIFF
--- a/app/Resources/patterns/definition-list.mustache
+++ b/app/Resources/patterns/definition-list.mustache
@@ -1,0 +1,6 @@
+<dl>
+    {{#items}}
+        <dt>{{{term}}}</dt>
+        <dd>{{{descriptor}}}</dd>
+    {{/items}}
+</dl>

--- a/app/Resources/views/about-people.html.twig
+++ b/app/Resources/views/about-people.html.twig
@@ -1,0 +1,27 @@
+{% extends '::page.html.twig' %}
+
+{% block title %}{{ title }} | About{% endblock %}
+
+{% block info_bar %}
+
+    {{ info_bar('This page is incomplete.') }}
+
+{% endblock %}
+
+{% block body %}
+
+    {{ render_pattern(contentHeader) }}
+
+    <div class="wrapper u-pad-top">
+
+        {{ render_pattern(menuLink) }}
+
+    </div>
+
+    <div class="wrapper">
+
+        {{ render_pattern(menu) }}
+
+    </div>
+
+{% endblock %}

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -1,13 +1,39 @@
 {% extends '::page.html.twig' %}
 
-{% block info_bar %}
-
-    {{ info_bar('This page is incomplete.') }}
-
-{% endblock %}
+{% block title %}{{ title }}{% if title != 'About' %} | About{% endif %}{% endblock %}
 
 {% block body %}
 
     {{ render_pattern(contentHeader) }}
+
+    <div class="wrapper u-pad-top">
+
+        {{ render_pattern(menuLink) }}
+
+    </div>
+
+    <div class="wrapper u-pad-top">
+
+        <div class="grid">
+
+            <div class="grid__item medium--six-twelfths push--large--three-twelfths">
+
+                {% for part in body %}
+
+                    {{ render_pattern(part) }}
+
+                {% endfor %}
+
+            </div>
+
+        </div>
+
+    </div>
+
+    <div class="wrapper">
+
+        {{ render_pattern(menu) }}
+
+    </div>
 
 {% endblock %}

--- a/app/Resources/views/annual-reports.html.twig
+++ b/app/Resources/views/annual-reports.html.twig
@@ -1,0 +1,13 @@
+{% extends '::page.html.twig' %}
+
+{% block info_bar %}
+
+    {{ info_bar('This page is incomplete.') }}
+
+{% endblock %}
+
+{% block body %}
+
+    {{ render_pattern(contentHeader) }}
+
+{% endblock %}

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -11,10 +11,41 @@ about:
     defaults:
          _controller: AppBundle:About:about
 
+about-early-career:
+    path: /about/early-career
+    defaults:
+         _controller: AppBundle:About:earlyCareer
+
+about-innovation:
+    path: /about/innovation
+    defaults:
+         _controller: AppBundle:About:innovation
+
+about-openness:
+    path: /about/openness
+    defaults:
+         _controller: AppBundle:About:openness
+
+about-peer-review:
+    path: /about/peer-review
+    defaults:
+         _controller: AppBundle:About:peerReview
+
+about-people:
+    path: /about/people/{type}
+    defaults:
+         _controller: AppBundle:About:people
+         type: ''
+
 alerts:
     path: /alerts
     defaults:
          _controller: AppBundle:Alerts:alerts
+
+annual-reports:
+    path: /annual-reports
+    defaults:
+         _controller: AppBundle:AnnualReports:list
 
 archive:
     path: /archive

--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -2,20 +2,179 @@
 
 namespace eLife\Journal\Controller;
 
+use eLife\Journal\ViewModel\DefinitionList;
+use eLife\Journal\ViewModel\Paragraph;
+use eLife\Patterns\ViewModel\ArticleSection;
 use eLife\Patterns\ViewModel\ContentHeaderNonArticle;
+use eLife\Patterns\ViewModel\Link;
+use eLife\Patterns\ViewModel\Listing;
+use eLife\Patterns\ViewModel\SectionListing;
+use eLife\Patterns\ViewModel\SectionListingLink;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final class AboutController extends Controller
 {
-    public function aboutAction() : Response
+    public function aboutAction(Request $request) : Response
     {
-        $arguments = $this->defaultPageArguments();
+        $arguments = $this->aboutPageArguments($request);
 
         $arguments['title'] = 'About';
 
         $arguments['contentHeader'] = ContentHeaderNonArticle::basic('About eLife', false,
-            'Pain-free publishing for your best science.');
+            'We want to improve all aspects of research communication in support of excellence in science.');
+
+        $arguments['body'] = [
+            new Paragraph('eLife is a non-profit organisation inspired by research funders and led by scientists. Our mission is to help scientists accelerate discovery by operating a platform for research communication that encourages and recognises the most responsible behaviours in science.'),
+            new Paragraph('eLife publishes important research in all areas of the life and biomedical sciences. The research is selected and evaluated by working scientists and is made freely available to all readers without delay. eLife also invests in innovation through open-source tool development to accelerate research communication and discovery. Our work is guided by the communities we serve.'),
+            new Paragraph('eLife was founded in 2011 by the Howard Hughes Medical Institute, the Max Planck Society and the Wellcome Trust, who provide financial support and strategic guidance. In 2017, eLife introduced publication fees to cover some of our core publishing costs. Annual reports and financial statements are openly available.'),
+            ArticleSection::basic('Related links', 2,
+                $this->render(Listing::unordered([
+                    '<a href="'.$this->get('router')->generate('inside-elife').'">Inside eLife</a>',
+                    '<a href="'.$this->get('router')->generate('annual-reports').'">Annual reports</a>',
+                    '<a href="'.$this->get('router')->generate('press-packs').'">For the press</a>',
+                    '<a href="'.$this->get('router')->generate('resources').'">Resources to download</a>',
+                ], 'bullet'))),
+        ];
 
         return new Response($this->get('templating')->render('::about.html.twig', $arguments));
+    }
+
+    public function peerReviewAction(Request $request) : Response
+    {
+        $arguments = $this->aboutPageArguments($request);
+
+        $arguments['title'] = 'Peer review';
+
+        $arguments['contentHeader'] = ContentHeaderNonArticle::basic($arguments['title'], false,
+            'Our goal at eLife is to publish papers that our reviewers and editors find authoritative, rigorous, insightful, enlightening or just beautiful.');
+
+        $arguments['body'] = [
+            new Paragraph('At eLife, we publish highly influential research, in the form of <a href="'.$this->get('router')->generate('article-type', ['type' => 'research-article']).'">Research Articles</a> (with no limits to the length or number of figures), <a href="'.$this->get('router')->generate('article-type', ['type' => 'short-report']).'">Short Reports</a>, <a href="'.$this->get('router')->generate('article-type', ['type' => 'tools-resources']).'">Tools and Resources</a>, and <a href="'.$this->get('router')->generate('article-type', ['type' => 'research-advance']).'">Research Advances</a> (substantial developments that build on previous eLife papers). eLife is also home to a rich selection of <a href="'.$this->get('router')->generate('magazine').'">Magazine</a> content, including <a href="'.$this->get('router')
+                    ->generate('article-type', ['type' => 'editorial']).'">Editorials</a>, essays and opinions (<a href="'.$this->get('router')->generate('article-type', ['type' => 'feature']).'">Feature Articles</a>), expert commentaries on recent papers (<a href="'.$this->get('router')->generate('article-type', ['type' => 'insight']).'">Insights</a>), <a href="'.$this->get('router')->generate('podcast').'">podcasts</a>, and interviews. For details and requirements for each type of submission, please consult our Author Guide and Policies.'),
+            new Paragraph('We do not artificially limit the number of articles we publish or have a set acceptance rate. Rather, we rely on the judgment of the working scientists who serve as our editors to select papers for peer review and publication. eLife does not support the Impact Factor.'),
+            new Paragraph('Our goal is to make peer review constructive and collaborative: initial decisions are delivered quickly; working scientists make all editorial decisions; and revision requests are consolidated following an open, internal consultation among reviewers to deliver a single, concise set of the essential revisions. Post-review decisions and author responses for published papers are available for all to read.'),
+            new Paragraph('Regularly updated metrics relating to the eLife editorial process are available in our Author Guide.'),
+            ArticleSection::basic('Related links', 2,
+                $this->render(Listing::unordered([
+                    '<a href="https://doi.org/10.7554/eLife.05770">The pleasure of publishing</a>',
+                    '<a href="https://doi.org/10.7554/eLife.11326">What makes an eLife paper in epidemiology and global health?</a>',
+                    '<a href="https://doi.org/10.7554/eLife.07158">Theory, models and biology</a>',
+                    '<a href="https://submit.elifesciences.org/html/elife_author_instructions.html">Submission guidelines</a>',
+                    '<a href="'.$this->get('router')->generate('alerts').'">Sign up for alerts</a>',
+                ], 'bullet'))),
+        ];
+
+        return new Response($this->get('templating')->render('::about.html.twig', $arguments));
+    }
+
+    public function opennessAction(Request $request) : Response
+    {
+        $arguments = $this->aboutPageArguments($request);
+
+        $arguments['title'] = 'Openness';
+
+        $arguments['contentHeader'] = ContentHeaderNonArticle::basic($arguments['title'], false,
+            'We believe that open access to research findings and associated data has the potential to revolutionise the scientific enterprise.');
+
+        $arguments['body'] = [
+            new Paragraph('Having free and open access to the outcomes of research helps make achievements more visible, accessible and usable – ultimately accelerating discoveries and their applications.'),
+            new Paragraph('At eLife, we are actively working to promote openness by:'),
+            new DefinitionList([
+                'Providing open access to research results' => 'We publish using the Creative Commons Attribution (CC-BY) license [link] so that users can read, download and reuse text and data for free – provided the authors are given appropriate credit. We also distribute content to digital repositories and other networks.',
+                'Promoting understanding of research' => 'For selected papers, we prepare non-technical summaries (eLife digests) so that the research we publish is accessible to a broader audience, including scientists in other fields, students, funders, policy makers and others.',
+                'Supporting reproducibility' => 'eLife authors are encouraged to publish their work in full and are required to provide the key underlying data as part of their paper. We support projects such as Research Resource Identifiers (RRIDs) that promote unambiguous identification of reagents and materials. eLife is also the publishing partner for the Reproducibility Project in Cancer Biology.',
+                'Making our software open-source' => 'The tools we develop to support research communication, including eLife Lens and Continuum, are made openly available so that others can use and build upon them without constraint.',
+            ]),
+            ArticleSection::basic('Related links', 2,
+                $this->render(Listing::unordered([
+                    '<a href="https://creativecommons.org/licenses/by/4.0/">Our copyright license: Creative Commons Attribution (CC-BY)</a>',
+                    '<a href="https://medium.com/@elife">eLife on medium.com</a>',
+                    '<a href="http://www.budapestopenaccessinitiative.org/">The Budapest Open Access Initiative (BOAI)</a>',
+                ], 'bullet'))),
+        ];
+
+        return new Response($this->get('templating')->render('::about.html.twig', $arguments));
+    }
+
+    public function innovationAction(Request $request) : Response
+    {
+        $arguments = $this->aboutPageArguments($request);
+
+        $arguments['title'] = 'Innovation';
+
+        $arguments['contentHeader'] = ContentHeaderNonArticle::basic($arguments['title'], false,
+            'eLife invests in open-source technology to deliver effective solutions to accelerate research communication and discovery.');
+
+        $arguments['body'] = [
+            new Paragraph('eLife invests heavily in software development, new product design, collaboration and outreach so that the potential for improvements in the digital communication of new research can start to be realised. We support the development of open-source tools, with extensible capabilities, that can be used, adopted and modified by any interested party to help move towards an ecosystem that serves science and scientists as efficiently and as cost-effectively as possible.'),
+            new Paragraph('The eLife Innovation Initiative is a separately funded effort aimed at accelerating the development of technology and process innovations from creative individuals and teams within the academic and technology industries. The primary outputs of the Initiative are open tools, technologies and processes aimed at improving the discovery, sharing, consumption and evaluation of scientific research.'),
+            new Paragraph('Through this Initiative, we’re always on the lookout for opportunities to engage with the best emerging talent and ideas at the interface of research and technology. You can find out more about some of these engagements on <a href="'.$this->get('router')->generate('labs').'">eLife Labs</a>, or contact our Innovation Officer for more information (<a href="mailto:innovation@elifesciences.org">innovation@elifesciences.org</a>).'),
+        ];
+
+        return new Response($this->get('templating')->render('::about.html.twig', $arguments));
+    }
+
+    public function earlyCareerAction(Request $request) : Response
+    {
+        $arguments = $this->aboutPageArguments($request);
+
+        $arguments['title'] = 'Early-Career Scientists';
+
+        $arguments['contentHeader'] = ContentHeaderNonArticle::basic($arguments['title'], false,
+            'The community behind eLife wants to help address some of the pressures on early-career scientists.');
+
+        $arguments['body'] = [
+            new Paragraph('The community behind eLife – including the research funders who support the journal, the editors and referees who run the peer-review process, and our Early-Career Advisory Group – are keenly aware of the pressures faced by junior investigators, and are working to create a more positive publishing experience that will, among other things, help early-career researchers receive the recognition they deserve.'),
+            new Paragraph('eLife supports and showcases early-career scientists and their work in a number of ways:'),
+            new DefinitionList([
+                'Magazine features' => 'Early-career researchers and issues of concern to them are regularly featured in interviews, podcasts and articles in the Magazine section of eLife',
+                '<a href="'.$this->get('router')->generate('events').'">#ECRWednesday Webinars</a>' => 'A platform for the early-career community to share opportunities and explore issues around building a successful research career, on the last Wednesday of every month.',
+                'Events' => 'We offer speakers and funding for scientific meetings organised for and by early-career researchers.',
+                'Travel grants' => 'eLife offers funding to help early-career scientists get exposure and recognition for their work among leading scientists in their fields.',
+                'Involvement in peer review' => 'eLife encourages reviewers to involve junior colleagues as co-reviewers; we involve outstanding early-stage researchers as reviewers in their own right; and we enable all reviewers to receive credit for their contributions through services such as Publons and ORCID',
+                'Taking advice' => 'eLife has invited a group of talented graduate students, postdocs and junior group leaders from laboratories across the world to our Early-Career Advisory Group to help guide the direction of the journal and to help us reshape science publishing. Learn more and sign up to have your say.',
+            ]),
+            new Paragraph('For the latest in our work to support early-career scientists, explore our <a href="'.$this->get('router')->generate('community').'">Community</a> page and sign up for eLife News for Early-Career Researchers.'),
+        ];
+
+        return new Response($this->get('templating')->render('::about.html.twig', $arguments));
+    }
+
+    public function peopleAction(Request $request) : Response
+    {
+        $arguments = $this->aboutPageArguments($request);
+
+        $arguments['title'] = 'Editors and people';
+
+        $arguments['contentHeader'] = ContentHeaderNonArticle::basic($arguments['title']);
+
+        return new Response($this->get('templating')->render('::about-people.html.twig', $arguments));
+    }
+
+    private function aboutPageArguments(Request $request) : array
+    {
+        $arguments = $this->defaultPageArguments();
+
+        $arguments['menuLink'] = new SectionListingLink('All sections', 'sections');
+
+        $menuItems = [
+            'About eLife' => $this->get('router')->generate('about'),
+            'Peer review' => $this->get('router')->generate('about-peer-review'),
+            'Openness' => $this->get('router')->generate('about-openness'),
+            'Innovation' => $this->get('router')->generate('about-innovation'),
+            'Early-Career Scientists' => $this->get('router')->generate('about-early-career'),
+            'Editors and people' => $this->get('router')->generate('about-people'),
+        ];
+
+        $currentPath = $this->get('router')->generate($request->attributes->get('_route'), $request->attributes->get('_route_params'));
+
+        $menuItems = array_map(function (string $text, string $path) use ($currentPath) {
+            return new Link($text, $path, $path === $currentPath);
+        }, array_keys($menuItems), array_values($menuItems));
+
+        $arguments['menu'] = new SectionListing('sections', $menuItems, true);
+
+        return $arguments;
     }
 }

--- a/src/Controller/AnnualReportsController.php
+++ b/src/Controller/AnnualReportsController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace eLife\Journal\Controller;
+
+use eLife\Patterns\ViewModel\ContentHeaderNonArticle;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AnnualReportsController extends Controller
+{
+    public function listAction() : Response
+    {
+        $arguments = $this->defaultPageArguments();
+
+        $arguments['title'] = 'Annual reports';
+
+        $arguments['contentHeader'] = ContentHeaderNonArticle::basic($arguments['title']);
+
+        return new Response($this->get('templating')->render('::annual-reports.html.twig', $arguments));
+    }
+}

--- a/src/ViewModel/DefinitionList.php
+++ b/src/ViewModel/DefinitionList.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace eLife\Journal\ViewModel;
+
+use Assert\Assertion;
+use eLife\Patterns\ArrayAccessFromProperties;
+use eLife\Patterns\ArrayFromProperties;
+use eLife\Patterns\SimplifyAssets;
+use eLife\Patterns\ViewModel;
+
+final class DefinitionList implements ViewModel
+{
+    use ArrayAccessFromProperties;
+    use ArrayFromProperties;
+    use SimplifyAssets;
+
+    private $items;
+
+    public function __construct(array $items)
+    {
+        Assertion::notEmpty($items);
+
+        $this->items = array_map(function (string $term, string $descriptor) {
+            return compact('term', 'descriptor');
+        }, array_keys($items), array_values($items));
+    }
+
+    public function getTemplateName() : string
+    {
+        return '/elife/journal/patterns/definition-list.mustache';
+    }
+}

--- a/test/Controller/AboutControllerTest.php
+++ b/test/Controller/AboutControllerTest.php
@@ -11,7 +11,7 @@ final class AboutControllerTest extends PageTestCase
     {
         $client = static::createClient();
 
-        $crawler = $client->request('GET', '/about');
+        $crawler = $client->request('GET', $this->getUrl());
 
         $this->assertSame(200, $client->getResponse()->getStatusCode());
         $this->assertSame('About eLife', $crawler->filter('.content-header__title')->text());
@@ -32,8 +32,8 @@ final class AboutControllerTest extends PageTestCase
         $this->assertSame('/about', $crawler->filter('link[rel="canonical"]')->attr('href'));
         $this->assertSame('http://localhost/about', $crawler->filter('meta[property="og:url"]')->attr('content'));
         $this->assertSame('About', $crawler->filter('meta[property="og:title"]')->attr('content'));
-        $this->assertSame('Pain-free publishing for your best science.', $crawler->filter('meta[property="og:description"]')->attr('content'));
-        $this->assertSame('Pain-free publishing for your best science.', $crawler->filter('meta[name="description"]')->attr('content'));
+        $this->assertSame('We want to improve all aspects of research communication in support of excellence in science.', $crawler->filter('meta[property="og:description"]')->attr('content'));
+        $this->assertSame('We want to improve all aspects of research communication in support of excellence in science.', $crawler->filter('meta[name="description"]')->attr('content'));
         $this->assertSame('summary', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
     }
 

--- a/test/Controller/AboutEarlyCareerControllerTest.php
+++ b/test/Controller/AboutEarlyCareerControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace test\eLife\Journal\Controller;
+
+final class AboutEarlyCareerControllerTest extends PageTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_the_innovation_page()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('Early-Career Scientists', $crawler->filter('.content-header__title')->text());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_metadata()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl().'?foo');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertSame('Early-Career Scientists | About | eLife', $crawler->filter('title')->text());
+        $this->assertSame('/about/early-career', $crawler->filter('link[rel="canonical"]')->attr('href'));
+        $this->assertSame('http://localhost/about/early-career', $crawler->filter('meta[property="og:url"]')->attr('content'));
+        $this->assertSame('Early-Career Scientists', $crawler->filter('meta[property="og:title"]')->attr('content'));
+        $this->assertSame('The community behind eLife wants to help address some of the pressures on early-career scientists.', $crawler->filter('meta[property="og:description"]')->attr('content'));
+        $this->assertSame('The community behind eLife wants to help address some of the pressures on early-career scientists.', $crawler->filter('meta[name="description"]')->attr('content'));
+        $this->assertSame('summary', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
+    }
+
+    protected function getUrl() : string
+    {
+        return '/about/early-career';
+    }
+}

--- a/test/Controller/AboutInnovationControllerTest.php
+++ b/test/Controller/AboutInnovationControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace test\eLife\Journal\Controller;
+
+final class AboutInnovationControllerTest extends PageTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_the_innovation_page()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('Innovation', $crawler->filter('.content-header__title')->text());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_metadata()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl().'?foo');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertSame('Innovation | About | eLife', $crawler->filter('title')->text());
+        $this->assertSame('/about/innovation', $crawler->filter('link[rel="canonical"]')->attr('href'));
+        $this->assertSame('http://localhost/about/innovation', $crawler->filter('meta[property="og:url"]')->attr('content'));
+        $this->assertSame('Innovation', $crawler->filter('meta[property="og:title"]')->attr('content'));
+        $this->assertSame('eLife invests in open-source technology to deliver effective solutions to accelerate research communication and discovery.', $crawler->filter('meta[property="og:description"]')->attr('content'));
+        $this->assertSame('eLife invests in open-source technology to deliver effective solutions to accelerate research communication and discovery.', $crawler->filter('meta[name="description"]')->attr('content'));
+        $this->assertSame('summary', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
+    }
+
+    protected function getUrl() : string
+    {
+        return '/about/innovation';
+    }
+}

--- a/test/Controller/AboutOpennessControllerTest.php
+++ b/test/Controller/AboutOpennessControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace test\eLife\Journal\Controller;
+
+final class AboutOpennessControllerTest extends PageTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_the_openness_page()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('Openness', $crawler->filter('.content-header__title')->text());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_metadata()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl().'?foo');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertSame('Openness | About | eLife', $crawler->filter('title')->text());
+        $this->assertSame('/about/openness', $crawler->filter('link[rel="canonical"]')->attr('href'));
+        $this->assertSame('http://localhost/about/openness', $crawler->filter('meta[property="og:url"]')->attr('content'));
+        $this->assertSame('Openness', $crawler->filter('meta[property="og:title"]')->attr('content'));
+        $this->assertSame('We believe that open access to research findings and associated data has the potential to revolutionise the scientific enterprise.', $crawler->filter('meta[property="og:description"]')->attr('content'));
+        $this->assertSame('We believe that open access to research findings and associated data has the potential to revolutionise the scientific enterprise.', $crawler->filter('meta[name="description"]')->attr('content'));
+        $this->assertSame('summary', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
+    }
+
+    protected function getUrl() : string
+    {
+        return '/about/openness';
+    }
+}

--- a/test/Controller/AboutPeerReviewControllerTest.php
+++ b/test/Controller/AboutPeerReviewControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace test\eLife\Journal\Controller;
+
+final class AboutPeerReviewControllerTest extends PageTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_the_peer_review_page()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('Peer review', $crawler->filter('.content-header__title')->text());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_metadata()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl().'?foo');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertSame('Peer review | About | eLife', $crawler->filter('title')->text());
+        $this->assertSame('/about/peer-review', $crawler->filter('link[rel="canonical"]')->attr('href'));
+        $this->assertSame('http://localhost/about/peer-review', $crawler->filter('meta[property="og:url"]')->attr('content'));
+        $this->assertSame('Peer review', $crawler->filter('meta[property="og:title"]')->attr('content'));
+        $this->assertSame('Our goal at eLife is to publish papers that our reviewers and editors find authoritative, rigorous, insightful, enlightening or just beautiful.', $crawler->filter('meta[property="og:description"]')->attr('content'));
+        $this->assertSame('Our goal at eLife is to publish papers that our reviewers and editors find authoritative, rigorous, insightful, enlightening or just beautiful.', $crawler->filter('meta[name="description"]')->attr('content'));
+        $this->assertSame('summary', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
+    }
+
+    protected function getUrl() : string
+    {
+        return '/about/peer-review';
+    }
+}

--- a/test/Controller/AboutPeopleControllerTest.php
+++ b/test/Controller/AboutPeopleControllerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace test\eLife\Journal\Controller;
+
+final class AboutPeopleControllerTest extends PageTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_the_people_page()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl());
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('Editors and people', $crawler->filter('.content-header__title')->text());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_metadata()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', $this->getUrl().'?foo');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+        $this->assertSame('Editors and people | About | eLife', $crawler->filter('title')->text());
+        $this->assertSame('/about/people', $crawler->filter('link[rel="canonical"]')->attr('href'));
+        $this->assertSame('http://localhost/about/people', $crawler->filter('meta[property="og:url"]')->attr('content'));
+        $this->assertSame('Editors and people', $crawler->filter('meta[property="og:title"]')->attr('content'));
+        $this->assertSame('summary', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
+    }
+
+    protected function getUrl() : string
+    {
+        return '/about/people';
+    }
+}

--- a/test/Controller/AnnualReportsControllerTest.php
+++ b/test/Controller/AnnualReportsControllerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace test\eLife\Journal\Controller;
+
+final class AnnualReportsControllerTest extends PageTestCase
+{
+    /**
+     * @test
+     */
+    public function it_displays_the_annual_reports_page()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/annual-reports');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame('Annual reports', $crawler->filter('.content-header__title')->text());
+    }
+
+    protected function getUrl() : string
+    {
+        return '/annual-reports';
+    }
+}


### PR DESCRIPTION
Add the text in the controller is a bit annoying, it would be ok at the moment to do it in the Twig template, but as soon as someone wants to add something that would be a normal pattern we're mixing where the content lives. Given we're not optimising for editing these (by hard-coding the text), I think it's ok to live with it.