### PR TITLE
Updated elife/patterns to f93d4bc: Updated pattern-library to d057ae4: ELPP-2075 squashed

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -840,12 +840,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "d1cca30611f1804c5a0e2aa453d9f4cb15e91466"
+                "reference": "f93d4bc39516aecfdbf69181136127df1c7e4ffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/d1cca30611f1804c5a0e2aa453d9f4cb15e91466",
-                "reference": "d1cca30611f1804c5a0e2aa453d9f4cb15e91466",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/f93d4bc39516aecfdbf69181136127df1c7e4ffe",
+                "reference": "f93d4bc39516aecfdbf69181136127df1c7e4ffe",
                 "shasum": ""
             },
             "require": {
@@ -882,11 +882,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "support": {
-                "source": "https://github.com/elifesciences/patterns-php/tree/master",
-                "issues": "https://github.com/elifesciences/patterns-php/issues"
-            },
-            "time": "2017-03-15 13:08:50"
+            "time": "2017-03-16 07:45:07"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/56/ which resulted in this pull request.