### PR TITLE
Updated elife/patterns to 1b78664: Updated pattern-library to dd16ea0: Stop metrics buttons from linking

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "83ee6894d86e67b8cde5e4a33cd992bafab24812"
+                "reference": "1b78664132d0240fea70b26d12e83b1df4975acf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/83ee6894d86e67b8cde5e4a33cd992bafab24812",
-                "reference": "83ee6894d86e67b8cde5e4a33cd992bafab24812",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/1b78664132d0240fea70b26d12e83b1df4975acf",
+                "reference": "1b78664132d0240fea70b26d12e83b1df4975acf",
                 "shasum": ""
             },
             "require": {
@@ -885,11 +885,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "support": {
-                "source": "https://github.com/elifesciences/patterns-php/tree/master",
-                "issues": "https://github.com/elifesciences/patterns-php/issues"
-            },
-            "time": "2017-03-30 13:10:23"
+            "time": "2017-04-01 08:38:02"
         },
         {
             "name": "guzzlehttp/guzzle",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/76/ which resulted in this pull request.