### PR TITLE
Improving exception on too large image sizes

### DIFF
--- a/src/Helper/CreatesIiifUri.php
+++ b/src/Helper/CreatesIiifUri.php
@@ -14,7 +14,7 @@ trait CreatesIiifUri
         $size = 'full';
 
         if (($width && $width > ($image->getWidth() * 2)) || ($height && $height > ($image->getHeight() * 2))) {
-            throw new InvalidArgumentException('Unable to scale the image that large');
+            throw new InvalidArgumentException("Unable to scale the image $uri that large (requested width: $width, requested height: $height; actual width: {$image->getWidth()}, actual height {$image->getHeight()})");
         }
 
         if ($width && $height) {


### PR DESCRIPTION
Becomes
```
"Uncaught PHP Exception InvalidArgumentException: \"Unable to scale the image https://iiif.elifesciences.org/journal-cms:collection/1970-01/test-tubes-blue-large.png that large (requested width: 1800, requested height: 900; actual width: 1200, actual height 322)\" at /srv/journal/src/Helper/CreatesIiifUri.php line 17"
```