### PR TITLE
Revert back to using OptiPNG rather than Zopfli

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,9 +5,9 @@ const favicons = require('gulp-favicons');
 const gulp = require('gulp');
 const imageMin = require('gulp-imagemin');
 const imageMinMozjpeg = require('imagemin-mozjpeg');
+const imageMinOptipng = require('imagemin-optipng');
 const imageMinSvgo = require('imagemin-svgo');
 const imageMinWebp = require('imagemin-webp');
-const imageMinZopfli = require('imagemin-zopfli');
 const merge = require('merge-stream');
 const responsive = require('gulp-responsive');
 const rev = require('gulp-rev-all');
@@ -41,8 +41,8 @@ gulp.task('favicons:build', ['favicons:clean'], () => {
             },
         }))
         .pipe(imageMin([
-            imageMinZopfli({
-                more: true,
+            imageMinOptipng({
+                optimizationLevel: 4,
             }),
         ]))
         .pipe(gulp.dest('./build/assets/favicons'));
@@ -115,12 +115,12 @@ gulp.task('images', ['images:banners', 'images:logos', 'images:svgs'], () => {
                 quality: 75,
                 progressive: true,
             }),
+            imageMinOptipng({
+                optimizationLevel: 4,
+            }),
             imageMinSvgo({}),
             imageMinWebp({
                 quality: 65,
-            }),
-            imageMinZopfli({
-                more: true,
             }),
         ]))
         .pipe(gulp.dest('./build/assets/images'));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1625,7 +1625,7 @@
     },
     "imagemin-optipng": {
       "version": "5.2.1",
-      "from": "imagemin-optipng@>=5.1.0 <6.0.0",
+      "from": "imagemin-optipng@latest",
       "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz"
     },
     "imagemin-svgo": {
@@ -1637,11 +1637,6 @@
       "version": "4.0.0",
       "from": "imagemin-webp@latest",
       "resolved": "https://registry.npmjs.org/imagemin-webp/-/imagemin-webp-4.0.0.tgz"
-    },
-    "imagemin-zopfli": {
-      "version": "5.1.0",
-      "from": "imagemin-zopfli@latest",
-      "resolved": "https://registry.npmjs.org/imagemin-zopfli/-/imagemin-zopfli-5.1.0.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
@@ -1804,9 +1799,9 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-png": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "from": "is-png@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2484,9 +2479,9 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "optipng-bin": {
-      "version": "3.1.2",
+      "version": "3.1.4",
       "from": "optipng-bin@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz"
     },
     "orchestrator": {
       "version": "0.3.8",
@@ -3501,11 +3496,6 @@
       "version": "2.7.0",
       "from": "yauzl@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.7.0.tgz"
-    },
-    "zopflipng-bin": {
-      "version": "4.0.0",
-      "from": "zopflipng-bin@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/zopflipng-bin/-/zopflipng-bin-4.0.0.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
         "gulp-rev-all": "^0.9",
         "gulp-svg2png": "^2.0.2",
         "imagemin-mozjpeg": "^6.0",
+        "imagemin-optipng": "^5.2",
         "imagemin-svgo": "^5.2.1",
         "imagemin-webp": "^4.0",
-        "imagemin-zopfli": "^5.1",
         "merge-stream": "^1.0.1"
     }
 }


### PR DESCRIPTION
#403 replaced OptiPNG with Zopfli as it produces smaller files, but the increase on build time is excessive. The reverts the change.

(It will be possible to use something slow like Zopfli if we weren't building the assets on _every_ build, only when they changed.)