### PR TITLE
Updated elife/patterns to dfda006: Updated pattern-library to 95077e5: Change PoA & VoR indicators to be text

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "f2b170671801330b85f09044d6f597731a04f03d"
+                "reference": "dfda006a0256e92ae1753a0f125a22e177d23763"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/f2b170671801330b85f09044d6f597731a04f03d",
-                "reference": "f2b170671801330b85f09044d6f597731a04f03d",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/dfda006a0256e92ae1753a0f125a22e177d23763",
+                "reference": "dfda006a0256e92ae1753a0f125a22e177d23763",
                 "shasum": ""
             },
             "require": {
@@ -885,7 +885,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-05-05 12:15:09"
+            "time": "2017-05-05 13:58:52"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/115/ which resulted in this pull request.