### PR TITLE
Updated elife/patterns to df21a0d: Updated pattern-library to dbfbbd0: Do not hide any header ancestor in side-by-side view

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "e02937159a616cd4a9a9b0e0fb37e17bb34e69f2"
+                "reference": "df21a0ddb6c899d3ba91144f3a96667b266b975b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/e02937159a616cd4a9a9b0e0fb37e17bb34e69f2",
-                "reference": "e02937159a616cd4a9a9b0e0fb37e17bb34e69f2",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/df21a0ddb6c899d3ba91144f3a96667b266b975b",
+                "reference": "df21a0ddb6c899d3ba91144f3a96667b266b975b",
                 "shasum": ""
             },
             "require": {
@@ -885,7 +885,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-05-16 09:29:15"
+            "time": "2017-05-16 16:31:38"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/146/ which resulted in this pull request.