### PR TITLE
Updated elife/patterns to b98d2a3: Updated pattern-library to 22acbf2: Cater for non-existent jump links

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "d95972ce63f58600ea74ea3190ead98897706e66"
+                "reference": "b98d2a332080d68ef8b81a2604677ab39c04c810"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/d95972ce63f58600ea74ea3190ead98897706e66",
-                "reference": "d95972ce63f58600ea74ea3190ead98897706e66",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/b98d2a332080d68ef8b81a2604677ab39c04c810",
+                "reference": "b98d2a332080d68ef8b81a2604677ab39c04c810",
                 "shasum": ""
             },
             "require": {
@@ -885,7 +885,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-05-18 11:09:41"
+            "time": "2017-05-19 08:56:59"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/159/ which resulted in this pull request.