### PR TITLE
Using configured default host in signature tests

### DIFF
--- a/test/Helper/DownloadLinkUriGeneratorTest.php
+++ b/test/Helper/DownloadLinkUriGeneratorTest.php
@@ -26,9 +26,16 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     {
         static::bootKernel();
 
-        $this->downloadLinkUriGenerator = static::$kernel->getContainer()->get('elife.journal.helper.download_link_uri_generator');
-        $this->uriSigner = static::$kernel->getContainer()->get('uri_signer');
-        $this->defaultBaseUrl = static::$kernel->getContainer()->getParameter('router.request_context.host');
+        $container = static::$kernel->getContainer();
+        $this->downloadLinkUriGenerator = $container->get('elife.journal.helper.download_link_uri_generator');
+        $this->uriSigner = $container->get('uri_signer');
+        $this->defaultBaseUrl =
+            $container->getParameter('router.request_context.scheme')
+            .'://'
+            .$container->getParameter('router.request_context.host')
+            .($container->getParameter('router.request_context.base_url')
+                ? '/'.$container->getParameter('router.request_context.base_url')
+                : '');
     }
 
     /**
@@ -37,7 +44,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     public function it_generates_a_uri()
     {
         $this->assertSame(
-            $this->uriSigner->sign('http://'.$this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar'), 
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar'),
             $this->downloadLinkUriGenerator->generate(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'))
         );
     }


### PR DESCRIPTION
We cannot pass the Host header because there is no request object in this context. The default is retrievable from the configuration.

Also checked that when we load the generated URL we don't get a signature error, which was happening in ci.