### PR TITLE
Updated elife/patterns to 8a23943: Updated pattern-library to f134154: Avoid grid listing float drop

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "05ed3ca3ef4d4428084d39373393b30a7c85f698"
+                "reference": "8a2394352243eb8dda5f9fd3322dd540b32ff86b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/05ed3ca3ef4d4428084d39373393b30a7c85f698",
-                "reference": "05ed3ca3ef4d4428084d39373393b30a7c85f698",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/8a2394352243eb8dda5f9fd3322dd540b32ff86b",
+                "reference": "8a2394352243eb8dda5f9fd3322dd540b32ff86b",
                 "shasum": ""
             },
             "require": {
@@ -885,7 +885,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-05-25 13:33:40"
+            "time": "2017-05-25 13:57:42"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/179/ which resulted in this pull request.