### PR TITLE
Updated elife/patterns to 0ebdae5: Updated pattern-library to ff7ac03: Don't put contextual data all on one line until screen wide enough to take data

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:elifesciences/patterns-php.git",
-                "reference": "0dfa0a42aa635d2525232680d27ebb71d0a987a5"
+                "reference": "0ebdae59337fbc9d54ea31aceac85af745eb2e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/0dfa0a42aa635d2525232680d27ebb71d0a987a5",
-                "reference": "0dfa0a42aa635d2525232680d27ebb71d0a987a5",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/0ebdae59337fbc9d54ea31aceac85af745eb2e8a",
+                "reference": "0ebdae59337fbc9d54ea31aceac85af745eb2e8a",
                 "shasum": ""
             },
             "require": {
@@ -885,11 +885,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "support": {
-                "source": "https://github.com/elifesciences/patterns-php/tree/master",
-                "issues": "https://github.com/elifesciences/patterns-php/issues"
-            },
-            "time": "2017-05-31 13:32:09"
+            "time": "2017-05-31 14:10:57"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/192/ which resulted in this pull request.