### PR TITLE
Updated elife/patterns to b30ae9b: Remove pattern-library PRs build

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "429b0a246e362e1d0b26c7683cd049bc87ab82cb"
+                "reference": "b30ae9b41d233b5a53e002359ca413e87b61ab95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/429b0a246e362e1d0b26c7683cd049bc87ab82cb",
-                "reference": "429b0a246e362e1d0b26c7683cd049bc87ab82cb",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/b30ae9b41d233b5a53e002359ca413e87b61ab95",
+                "reference": "b30ae9b41d233b5a53e002359ca413e87b61ab95",
                 "shasum": ""
             },
             "require": {
@@ -876,16 +876,12 @@
                     "eLife\\Patterns\\": "./src"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "tests\\eLife\\Patterns\\": "./tests/src"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-06-01 15:19:22"
+            "time": "2017-06-02 14:57:38"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/198/ which resulted in this pull request.