### PR TITLE
New Relic check on production deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,6 @@ elifePipeline {
 
     stage 'Project tests', {
         lock('journal--ci') {
-            def newRelicStatus = elifeNewRelicStatus(26895928)
-            echo "New Relic status for journal--ci: ${newRelicStatus}"
             builderDeployRevision 'journal--ci', commit
             builderProjectTests 'journal--ci', '/srv/journal', ['/srv/journal/build/phpunit.xml', '/srv/journal/build/behat.xml'], ['smoke', 'project']
         }

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -13,8 +13,9 @@ elifePipeline {
     }
 
     stage 'Deploy to prod', {
-        def newRelicStatus = elifeNewRelicStatus(29775807)
-        echo "New Relic status for journal--prod: ${newRelicStatus}" 
+        if (!params.force) {
+            elifeNewRelicEnsureStatus(29775807, ["green"])
+        }
         elifeDeploySlackNotification 'journal', 'prod'
         builderDeployRevision 'journal--prod', commit, 'blue-green'
         builderSmokeTests 'journal--prod', '/srv/journal'


### PR DESCRIPTION
We check we are green, but we can always override and deploy anyway if needed to fix a problem