### PR TITLE
Ensure APM apdex is within green limit before deploying

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -14,7 +14,7 @@ elifePipeline {
 
     stage 'Deploy to prod', {
         if (!params.force) {
-            elifeNewRelicEnsureStatus(29775807, ["green"])
+            elifeNewRelicEnsureApdex(29775807)
         }
         elifeDeploySlackNotification 'journal', 'prod'
         builderDeployRevision 'journal--prod', commit, 'blue-green'


### PR DESCRIPTION
The minimum value can be customized with an additional parameter, the default is 0.85

Tested in https://ci--alfred.elifesciences.org/job/prod-journal/372/