### PR TITLE
Updated elife/patterns to 42be244: Updated pattern-library to 400a7e8: Update MathJax and use CommonHTML by default

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -843,12 +843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "d73a52c96ecb4b752b47a34d55d3694de911962c"
+                "reference": "42be244827faa6101a626e537d036bb1bbcf8e52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/d73a52c96ecb4b752b47a34d55d3694de911962c",
-                "reference": "d73a52c96ecb4b752b47a34d55d3694de911962c",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/42be244827faa6101a626e537d036bb1bbcf8e52",
+                "reference": "42be244827faa6101a626e537d036bb1bbcf8e52",
                 "shasum": ""
             },
             "require": {
@@ -881,7 +881,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-06-26 14:35:50"
+            "time": "2017-06-29 09:15:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/215/ which resulted in this pull request.