### PR TITLE
Fix NelmioSecurityBundle

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -45,5 +45,8 @@ nelmio_security:
         enforce:
             default-src:
               - 'https:'
+              - unsafe-inline
     forced_ssl:
+        whitelist:
+          - ^/ # Hack to disable redirect.
         hsts_max_age: 31536000 # 1 year


### PR DESCRIPTION
`unsafe-inline` allows local (and injected, eg New Relic) scripts/styles to work. Also disables the HTTP->HTTPS redirect by whitelisting all paths (bit of a hack), as this broke ELB's healthcheck.