### PR TITLE
Updated elife/patterns to 4f97eb2: Updated pattern-library to 5efb752: Remove padding from et al link

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -848,12 +848,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "021bfc99077efafc55f13e2b1ff49ab54a411536"
+                "reference": "4f97eb2eb1e3125e465308d41401c48bb70205e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/021bfc99077efafc55f13e2b1ff49ab54a411536",
-                "reference": "021bfc99077efafc55f13e2b1ff49ab54a411536",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/4f97eb2eb1e3125e465308d41401c48bb70205e8",
+                "reference": "4f97eb2eb1e3125e465308d41401c48bb70205e8",
                 "shasum": ""
             },
             "require": {
@@ -886,7 +886,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-07-04 16:05:40"
+            "time": "2017-07-05 09:03:51"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/220/ which resulted in this pull request.