### PR TITLE
Updated elife/patterns to 1f8ec61: Updated pattern-library to 8e1ee04: Make honeypot field not tab accessible

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -848,12 +848,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "4f97eb2eb1e3125e465308d41401c48bb70205e8"
+                "reference": "1f8ec610d598fe93334c83247f47cacdd50586e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/4f97eb2eb1e3125e465308d41401c48bb70205e8",
-                "reference": "4f97eb2eb1e3125e465308d41401c48bb70205e8",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/1f8ec610d598fe93334c83247f47cacdd50586e3",
+                "reference": "1f8ec610d598fe93334c83247f47cacdd50586e3",
                 "shasum": ""
             },
             "require": {
@@ -886,7 +886,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-07-05 09:03:51"
+            "time": "2017-07-05 15:24:31"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/221/ which resulted in this pull request.