### PR TITLE
Pin api-dummy

### DIFF
--- a/api-dummy.sha1
+++ b/api-dummy.sha1
@@ -1,0 +1,1 @@
+5f856a7fae175ebf5aba0ddad127c9bc39064182


### PR DESCRIPTION
When a project depends on the api-dummy, builder-base-formula requires it to be pinned