### PR TITLE
Allow for parameters environment variable

### DIFF
--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -111,6 +111,8 @@ class AppKernel extends Kernel
     {
         $builder = parent::buildContainer();
 
+        $builder->getParameterBag()->add($this->getEnvParameters()); // https://github.com/symfony/symfony/issues/7555
+
         $builder->addExpressionLanguageProvider(new ComposerLocateFunctionProvider());
 
         return $builder;


### PR DESCRIPTION
A quick win to allow for environment variables to override parameters already defined in `parameters.yml`.