### PR TITLE
Allow Monolog handlers to fail

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -17,7 +17,7 @@ monolog:
             excluded_404s:
                 - ^/
         composite:
-            type: group
+            type: whatfailuregroup
             members:
                 - text
                 - json

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,9 @@
             },
             "isometriks/spam-bundle": {
                 "Add field label": "https://github.com/isometriks/IsometriksSpamBundle/pull/9.patch"
+            },
+            "monolog/monolog": {
+                "Fix WhatFailureGroupHandler::handleBatch when the handler has processors": "https://github.com/Seldaek/monolog/pull/1022.patch"
             }
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "424f3fa45712df349af327f61f9bfc23",
+    "content-hash": "fd7e8f5dc4f20ee8f104b5e0b549edb9",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1387,6 +1387,9 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.0.x-dev"
+                },
+                "patches_applied": {
+                    "Fix WhatFailureGroupHandler::handleBatch when the handler has processors": "https://github.com/Seldaek/monolog/pull/1022.patch"
                 }
             },
             "autoload": {


### PR DESCRIPTION
If New Relic is installed, the app break when logging. This allows individual handlers to fail silently.