### PR TITLE
[WIP] Remove audio player from magazine template

### DIFF
--- a/app/Resources/views/magazine.html.twig
+++ b/app/Resources/views/magazine.html.twig
@@ -6,10 +6,6 @@
 
     {{ render_pattern(contentHeader) }}
 
-    {% if audio_player %}
-        {{ render_pattern(audio_player) }}
-    {% endif %}
-
     <div class="wrapper">
 
         {{ render_pattern(menuLink) }}


### PR DESCRIPTION
This is part of the pattern work for the content header image credit. This PR must be incorporated into the same deployment as https://github.com/elifesciences/pattern-library/pull/715.