### PR TITLE
Make all grid pagination pages full width

### DIFF
--- a/app/Resources/views/about-people.html.twig
+++ b/app/Resources/views/about-people.html.twig
@@ -14,13 +14,17 @@
 
     </div>
 
-    <div class="wrapper u-pad-top-lg">
+    {% embed 'grid/listing-one-column.html.twig' with {fullWidth: true} %}
 
-        {% for list in lists %}
-            {{ render_pattern(list) }}
-        {% endfor %}
+        {% block listing %}
 
-    </div>
+            {% for list in lists %}
+                {{ render_pattern(list) }}
+            {% endfor %}
+
+        {% endblock %}
+
+    {% endembed %}
 
     <div class="wrapper">
 

--- a/app/Resources/views/archive-year.html.twig
+++ b/app/Resources/views/archive-year.html.twig
@@ -6,10 +6,14 @@
 
     {{ render_pattern(contentHeader) }}
 
-    <div class="wrapper wrapper--listing">
+    {% embed 'grid/listing-one-column.html.twig' with {fullWidth: true} %}
 
-        {{ render_pattern(months) }}
+        {% block listing %}
 
-    </div>
+            {{ render_pattern(months) }}
+
+        {% endblock %}
+
+    {% endembed %}
 
 {% endblock %}

--- a/app/Resources/views/grid/listing-one-column.html.twig
+++ b/app/Resources/views/grid/listing-one-column.html.twig
@@ -4,7 +4,7 @@
 
     <div class="grid">
 
-        <div class="grid__item one-whole x-large--eight-twelfths push--x-large--two-twelfths grid-column">
+        <div class="grid__item one-whole{% if not fullWidth ?? false %} x-large--eight-twelfths push--x-large--two-twelfths{% endif %} grid-column">
 
             {{ listing|raw }}
 

--- a/app/Resources/views/labs.html.twig
+++ b/app/Resources/views/labs.html.twig
@@ -6,10 +6,14 @@
 
     {{ render_pattern(contentHeader) }}
 
-    <div class="wrapper wrapper--listing">
+    {% embed 'grid/listing-one-column.html.twig' with {fullWidth: true} %}
 
-        {{ render_pattern(listing) }}
+        {% block listing %}
 
-    </div>
+            {{ render_pattern(listing) }}
+
+        {% endblock %}
+
+    {% endembed %}
 
 {% endblock %}

--- a/app/Resources/views/pagination-grid.html.twig
+++ b/app/Resources/views/pagination-grid.html.twig
@@ -1,3 +1,5 @@
+{% set fullWidth = true %}
+
 {% extends '::pagination.html.twig' %}
 
 {% block listing %}

--- a/app/Resources/views/podcast.html.twig
+++ b/app/Resources/views/podcast.html.twig
@@ -4,10 +4,14 @@
 
     {{ render_pattern(contentHeader) }}
 
-    <div class="wrapper wrapper--listing">
+    {% embed 'grid/listing-one-column.html.twig' with {fullWidth: true} %}
 
-        {{ render_pattern(listing) }}
+        {% block listing %}
 
-    </div>
+            {{ render_pattern(listing) }}
+
+        {% endblock %}
+
+    {% endembed %}
 
 {% endblock %}

--- a/app/Resources/views/subjects.html.twig
+++ b/app/Resources/views/subjects.html.twig
@@ -4,16 +4,16 @@
 
 {% block body %}
 
-    <div class="wrapper">
+    {{ render_pattern(contentHeader) }}
 
-        {{ render_pattern(contentHeader) }}
+    {% embed 'grid/listing-one-column.html.twig' with {fullWidth: true} %}
 
-    </div>
+        {% block listing %}
 
-    <div class="wrapper wrapper--listing">
+            {{ render_pattern(subjects) }}
 
-        {{ render_pattern(subjects) }}
+        {% endblock %}
 
-    </div>
+    {% endembed %}
 
 {% endblock %}

--- a/app/Resources/views/who-we-work-with.html.twig
+++ b/app/Resources/views/who-we-work-with.html.twig
@@ -6,12 +6,16 @@
 
     {{ render_pattern(contentHeader) }}
 
-    <div class="wrapper wrapper--listing">
+    {% embed 'grid/listing-one-column.html.twig' with {fullWidth: true} %}
 
-        {% for listing in listings %}
-            {{ render_pattern(listing) }}
-        {% endfor %}
+        {% block listing %}
 
-    </div>
+            {% for listing in listings %}
+                {{ render_pattern(listing) }}
+            {% endfor %}
+
+        {% endblock %}
+
+    {% endembed %}
 
 {% endblock %}


### PR DESCRIPTION
Pages like https://elifesciences.org/labs?page=2 aren't currently full-width, which is wrong for grid listings.

This allows `listing-one-column.html.twig` to be full width, and is then reused by all full-width listing pages.