### PR TITLE
Fix image paths in critical css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -179,6 +179,7 @@ gulp.task('critical-css:generate', ['critical-css:clean'], (callback) => {
                 html: html,
                 src: uri,
                 include: criticalCssConfig.getInclusions(name),
+                pathPrefix: criticalCssConfig.assetPathPrefix,
                 minify: true,
                 dimensions: criticalCssConfig.dimensions,
                 timeout: 90000
@@ -285,6 +286,7 @@ const criticalCssConfig = (function () {
     return {
         baseUrl: 'http://localhost:8080',
         baseFilePath: './build/critical-css',
+        assetPathPrefix: '/assets/patterns/level-to-be-raised-from-by-actual-path-double-dot/',
         dimensions: [
             {
                 height: 1000,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -286,7 +286,7 @@ const criticalCssConfig = (function () {
     return {
         baseUrl: 'http://localhost:8080',
         baseFilePath: './build/critical-css',
-        assetPathPrefix: '/assets/patterns/',
+        assetPathPrefix: '/assets/patterns',
         dimensions: [
             {
                 height: 1000,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -179,7 +179,7 @@ gulp.task('critical-css:generate', ['critical-css:clean'], (callback) => {
                 html: html,
                 src: uri,
                 include: criticalCssConfig.getInclusions(name),
-                pathPrefix: criticalCssConfig.assetPathPrefix,
+                pathPrefix: `${criticalCssConfig.assetPathPrefix}/level-to-be-raised-from-by-actual-path-double-dot/`,
                 minify: true,
                 dimensions: criticalCssConfig.dimensions,
                 timeout: 90000
@@ -286,7 +286,7 @@ const criticalCssConfig = (function () {
     return {
         baseUrl: 'http://localhost:8080',
         baseFilePath: './build/critical-css',
-        assetPathPrefix: '/assets/patterns/level-to-be-raised-from-by-actual-path-double-dot/',
+        assetPathPrefix: '/assets/patterns/',
         dimensions: [
             {
                 height: 1000,


### PR DESCRIPTION
Fixes the broken asset paths in the critical css.

The third level of `/assets/patterns/level-to-be-raised-from-by-actual-path-double-dot/` is needed because the asset paths in the css begin `../`. This could be renamed to something better.