### PR TITLE
ELPP-1947 Deploy on continuumtest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,14 +24,18 @@ elifePipeline {
             )
         }
 
-        stage 'Deploy on demo', {
-            builderDeployRevision 'journal--demo', commit
-            builderSmokeTests 'journal--demo', '/srv/journal'
-        }
-
-        stage 'Deploy on continuumtest', {
-            builderDeployRevision 'journal--continuumtest', commit
-            builderSmokeTests 'journal--continuumtest', '/srv/journal'
+        stage 'Deploy on demo, continuumtest', {
+            def deployments = [
+                demo: {
+                    builderDeployRevision 'journal--demo', commit
+                    builderSmokeTests 'journal--demo', '/srv/journal'
+                },
+                continuumtest: {
+                    builderDeployRevision 'journal--continuumtest', commit
+                    builderSmokeTests 'journal--continuumtest', '/srv/journal'
+                }
+            ]
+            parallel deployments
         }
 
         stage 'Approval', {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,11 @@ elifePipeline {
             builderSmokeTests 'journal--demo', '/srv/journal'
         }
 
+        stage 'Deploy on continuumtest', {
+            builderDeployRevision 'journal--continuumtest', commit
+            builderSmokeTests 'journal--continuumtest', '/srv/journal'
+        }
+
         stage 'Approval', {
             elifeGitMoveToBranch commit, 'approved'
         }


### PR DESCRIPTION
Currently the deploy is performed daily. Projects should be transitioned to immediately deploy there as soon as tests are green.

If this is too slow, we can deploy `demo` and `continuumtest` in parallel.