### PR TITLE
Only make first item related on the first page

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -86,10 +86,10 @@ final class ArticlesController extends Controller
             $arguments['furtherReading'],
             $page,
             $perPage,
-            function (Model $model, int $i) {
+            function (Model $model, int $i) use ($page) {
                 $context = [];
 
-                if (0 === $i) {
+                if (0 === $i && 1 === $page) {
                     $context['isRelated'] = true;
                 }
 

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1709,6 +1709,7 @@ final class ArticleControllerTest extends PageTestCase
 
         $furtherReading = $crawler->filter('.listing-list-heading:contains("Further reading") + .listing-list > .listing-list__item');
         $this->assertCount(3, $furtherReading);
+        $this->assertCount(1, $crawler->filter('.listing-list__item--related'));
         $this->assertContains('Insight 1 title', $furtherReading->eq(0)->text());
         $this->assertContains('Insight 2 title', $furtherReading->eq(1)->text());
         $this->assertContains('Another article title', $furtherReading->eq(2)->text());
@@ -1717,6 +1718,7 @@ final class ArticleControllerTest extends PageTestCase
 
         $furtherReading = $crawler->filter('.listing-list__item');
         $this->assertCount(2, $furtherReading);
+        $this->assertCount(0, $crawler->filter('.listing-list__item--related'));
         $this->assertContains('Insight 3 title', $furtherReading->eq(0)->text());
         $this->assertContains('Insight 4 title', $furtherReading->eq(1)->text());
     }


### PR DESCRIPTION
#716 applied to all pages, meaning random items were hidden on larger screens.