### PR TITLE
Only run end2end tests explicitly marked for journal

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,8 @@ elifePipeline {
                     revision: commit,
                     folder: '/srv/journal',
                     concurrency: 'blue-green'
-                ]
+                ],
+                marker: 'journal'
             )
         }
 


### PR DESCRIPTION
This is not a big difference from the current set of tests, but some only targeting the API and using journal only accidentally have been excluded from the new marker.