### PR TITLE
Coupling to the ORCID OAuth response

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -77,6 +77,7 @@ hwi_oauth:
             client_secret: '%oauth2_client_secret%'
             access_token_url: '%api_url%/oauth2/token'
             authorization_url: '%api_url_public%/oauth2/authorize'
+            # to be audited: does this rely on proprietary extensions to the OAuth response from ORCID?
             paths:
                 identifier: orcid
                 nickname: name

--- a/test/Controller/AuthenticationTest.php
+++ b/test/Controller/AuthenticationTest.php
@@ -146,8 +146,6 @@ final class AuthenticationTest extends WebTestCase
                     'access_token' => 'token',
                     'expires_in' => 3920,
                     'token_type' => 'Bearer',
-                    'orcid' => '0000-0002-1825-0097',
-                    'name' => 'Josiah Carberry',
                 ])
             )
         );

--- a/test/WebTestCase.php
+++ b/test/WebTestCase.php
@@ -20,8 +20,6 @@ abstract class WebTestCase extends BaseWebTestCase
                 'access_token' => 'token',
                 'expires_in' => 3920,
                 'token_type' => 'Bearer',
-                'orcid' => '0000-0002-1825-0097',
-                'name' => 'Josiah Carberry',
             ],
             ['ROLE_USER', 'ROLE_OAUTH_USER']
         );


### PR DESCRIPTION
Currently profiles is exposing everything that comes through the ORCID OAuth token response. `orcid` and `name` are not part of the standard, so it's not mandatory for our `profile` implementation to provide them. And even if it wants to provide these values as part of the token response, they don't necessarily need to be named/modelled like the ORCID fields.