### PR TITLE
routing, fix three small typos

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -154,14 +154,14 @@ doi:
     defaults:
          _controller: AppBundle:Doi:doi
     requirements:
-        doi: 10.7554/eLife\.([a-z0-9-]+)
+        doi: 10\.7554/eLife\.([a-z0-9-]+)
 
 doi-sub:
     path: /lookup/doi/{doi}
     defaults:
          _controller: AppBundle:Doi:subDoi
     requirements:
-        doi: 10.7554/eLife\.([a-z0-9-.]+)
+        doi: 10\.7554/eLife\.([a-z0-9-.]+)
 
 download:
     path: /download/{uri}/{name}
@@ -284,7 +284,7 @@ terms:
          _controller: AppBundle:Terms:terms
 
 who-we-work-with:
-    path: who-we-work-with
+    path: /who-we-work-with
     defaults:
          _controller: AppBundle:WhoWeWorkWith:whoWeWorkWith
 


### PR DESCRIPTION
two fixes escape '.' in doi
third fixes a missing leading slash