### PR TITLE
Updated elife/patterns to 330e5ba: Updated pattern-library to 965fb0c: Stop initialising components if other patterns aren't available

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -954,12 +954,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "658b5b37c74ab0a9fb361b560f748045542e5daa"
+                "reference": "330e5ba90850b25e6f64739e63d11a2ebea5b2a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/658b5b37c74ab0a9fb361b560f748045542e5daa",
-                "reference": "658b5b37c74ab0a9fb361b560f748045542e5daa",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/330e5ba90850b25e6f64739e63d11a2ebea5b2a0",
+                "reference": "330e5ba90850b25e6f64739e63d11a2ebea5b2a0",
                 "shasum": ""
             },
             "require": {
@@ -992,7 +992,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-09-15T13:42:45+00:00"
+            "time": "2017-10-13T08:58:58+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run http://ci--alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/268/ which resulted in this pull request.