### PR TITLE
Updated elife/patterns to 63c7eaa: Updated pattern-library to 99618cf: Prevent social media icons repeating at larger font sizes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -954,12 +954,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "6a93838138ababac8330867bb25a90152cc42d47"
+                "reference": "63c7eaae8dcd93623e96cb48e814d6a808cb7850"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/6a93838138ababac8330867bb25a90152cc42d47",
-                "reference": "6a93838138ababac8330867bb25a90152cc42d47",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/63c7eaae8dcd93623e96cb48e814d6a808cb7850",
+                "reference": "63c7eaae8dcd93623e96cb48e814d6a808cb7850",
                 "shasum": ""
             },
             "require": {
@@ -992,7 +992,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2017-11-20T10:59:52+00:00"
+            "time": "2017-11-22T13:16:55+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/287/display/redirect which resulted in this pull request.