### PR TITLE
Add campaign tracking to technews link

### DIFF
--- a/src/Controller/LabsController.php
+++ b/src/Controller/LabsController.php
@@ -66,7 +66,7 @@ final class LabsController extends Controller
             'eLife Labs',
             $this->get('elife.journal.view_model.factory.content_header_image')->forLocalFile('labs'),
             'Exploring open-source solutions at the intersection of research and technology.
-Learn more about <a href="'.$this->get('router')->generate('about-innovation').'">innovation at eLife</a>, follow us on <a href="https://twitter.com/eLifeInnovation">Twitter</a>, or sign up for our <a href="https://crm.elifesciences.org/crm/tech-news">technology and innovation newsletter</a>.'
+Learn more about <a href="'.$this->get('router')->generate('about-innovation').'">innovation at eLife</a>, follow us on <a href="https://twitter.com/eLifeInnovation">Twitter</a>, or sign up for our <a href="https://crm.elifesciences.org/crm/tech-news?utm_source=Labs-home&utm_medium=website&utm_campaign=technews">technology and innovation newsletter</a>.'
         );
 
         return new Response($this->get('templating')->render('::labs.html.twig', $arguments));


### PR DESCRIPTION
- Update URL address to include GA utm tracking. 
- This doesn't affect the test (no text change).

@giorgiosironi hi Giorgio, a simple change proposed here to update a URL.