### PR TITLE
use window.location.assign rather than window.location.replace

### DIFF
--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -210,17 +210,17 @@
                             icon: '{{ absolute_url(asset('assets/favicons/favicon.svg')) }}'
                             {%- if not app.user %},
                             onLoginRequest: function () {
-                                window.location.replace('{{ path('log-in') }}');
+                                window.location.assign('{{ path('log-in') }}');
                             },
                             onSignupRequest: function () {
-                                window.location.replace('{{ path('log-in') }}');
+                                window.location.assign('{{ path('log-in') }}');
                             }
                             {%- else %},
                             onLogoutRequest: function () {
-                                window.location.replace('{{ path('log-out') }}');
+                                window.location.assign('{{ path('log-out') }}');
                             },
                             onProfileRequest: function () {
-                                window.location.replace('{{ path('profile', {id: app.user.username}) }}');
+                                window.location.assign('{{ path('profile', {id: app.user.username}) }}');
                             }
                             {%- endif %}
                         }],


### PR DESCRIPTION
The current use of `window.location.replace` causes issues with the browser history. `assign` is better.

To recreate the problem: go to the homepage, click on any article link, once on the article page open the annotation client and click the `Log in` link in the hypothesis client. Once you have been forwarded on, press back in the browser window and you will arrive at the homepage rather than the article page.

The expected behaviour is that the back button will result in the user being returned to the article page.