### PR TITLE
Update Critical and Penthouse

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,23 +37,6 @@
       "from": "ansi-styles@>=2.2.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
-    "apartment": {
-      "version": "1.1.1",
-      "from": "apartment@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/apartment/-/apartment-1.1.1.tgz",
-      "dependencies": {
-        "get-stdin": {
-          "version": "5.0.1",
-          "from": "get-stdin@5.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz"
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "from": "lodash@3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-        }
-      }
-    },
     "archive-type": {
       "version": "3.2.0",
       "from": "archive-type@>=3.0.1 <4.0.0",
@@ -562,9 +545,9 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz"
     },
     "critical": {
-      "version": "1.0.0",
-      "from": "critical@1.0.0",
-      "resolved": "https://registry.npmjs.org/critical/-/critical-1.0.0.tgz",
+      "version": "1.1.0",
+      "from": "critical@1.1.0",
+      "resolved": "https://registry.npmjs.org/critical/-/critical-1.1.0.tgz",
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
@@ -612,9 +595,9 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
         },
         "fs-extra": {
-          "version": "4.0.2",
+          "version": "4.0.3",
           "from": "fs-extra@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz"
         },
         "get-stdin": {
           "version": "5.0.1",
@@ -766,18 +749,6 @@
         }
       }
     },
-    "css-fork-pocketjoso": {
-      "version": "2.2.1",
-      "from": "css-fork-pocketjoso@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/css-fork-pocketjoso/-/css-fork-pocketjoso-2.2.1.tgz",
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "from": "source-map@^0.1.38",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
-        }
-      }
-    },
     "css-mediaquery": {
       "version": "0.1.2",
       "from": "css-mediaquery@>=0.1.2 <0.2.0",
@@ -804,6 +775,11 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         }
       }
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.26",
+      "from": "css-tree@1.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.26.tgz"
     },
     "css-what": {
       "version": "1.0.0",
@@ -1417,9 +1393,9 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
     },
     "fg-loadcss": {
-      "version": "1.3.1",
-      "from": "fg-loadcss@1.3.1",
-      "resolved": "https://registry.npmjs.org/fg-loadcss/-/fg-loadcss-1.3.1.tgz"
+      "version": "2.0.1",
+      "from": "fg-loadcss@>=2.0.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/fg-loadcss/-/fg-loadcss-2.0.1.tgz"
     },
     "figures": {
       "version": "1.7.0",
@@ -2063,14 +2039,14 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
     },
     "https-proxy-agent": {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "from": "https-proxy-agent@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "from": "debug@>=2.4.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+          "version": "3.1.0",
+          "from": "debug@^3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
         },
         "ms": {
           "version": "2.0.0",
@@ -2164,9 +2140,9 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
     },
     "inline-critical": {
-      "version": "2.4.2",
-      "from": "inline-critical@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inline-critical/-/inline-critical-2.4.2.tgz",
+      "version": "3.1.0",
+      "from": "inline-critical@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/inline-critical/-/inline-critical-3.1.0.tgz",
       "dependencies": {
         "cheerio": {
           "version": "0.22.0",
@@ -2199,9 +2175,9 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
         },
         "indent-string": {
-          "version": "3.1.0",
-          "from": "indent-string@3.1.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.1.0.tgz"
+          "version": "3.2.0",
+          "from": "indent-string@^3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz"
         },
         "isarray": {
           "version": "1.0.0",
@@ -2224,9 +2200,9 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
         },
         "resolve": {
-          "version": "1.3.3",
-          "from": "resolve@1.3.3",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz"
+          "version": "1.5.0",
+          "from": "resolve@>=1.5.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz"
         },
         "string_decoder": {
           "version": "1.0.3",
@@ -2511,9 +2487,9 @@
       "optional": true
     },
     "js-base64": {
-      "version": "2.3.2",
+      "version": "2.4.0",
       "from": "js-base64@>=2.1.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz"
     },
     "js-yaml": {
       "version": "3.7.0",
@@ -2956,6 +2932,11 @@
         }
       }
     },
+    "mdn-data": {
+      "version": "1.0.0",
+      "from": "mdn-data@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.0.0.tgz"
+    },
     "meow": {
       "version": "3.7.0",
       "from": "meow@>=3.3.0 <4.0.0",
@@ -3341,9 +3322,21 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
     },
     "penthouse": {
-      "version": "1.1.3",
+      "version": "1.3.0",
       "from": "penthouse@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/penthouse/-/penthouse-1.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/penthouse/-/penthouse-1.3.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "from": "debug@^3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
+        },
+        "ms": {
+          "version": "2.0.0",
+          "from": "ms@2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+        }
+      }
     },
     "performance-now": {
       "version": "0.2.0",
@@ -3552,9 +3545,9 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "puppeteer": {
-      "version": "0.13.0",
-      "from": "puppeteer@>=0.13.0 <0.14.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-0.13.0.tgz",
+      "version": "0.12.0",
+      "from": "puppeteer@>=0.12.0 <0.13.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-0.12.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.6.9",
@@ -4271,9 +4264,9 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uglify-js": {
-      "version": "3.2.0",
+      "version": "3.2.2",
       "from": "uglify-js@>=3.0.23 <4.0.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
       "dependencies": {
         "commander": {
           "version": "2.12.2",
@@ -4482,9 +4475,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
     },
     "ws": {
-      "version": "3.3.2",
+      "version": "3.3.3",
       "from": "ws@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz"
     },
     "xdg-basedir": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "dependencies": {
         "async": "^2.5.0",
-        "critical": "^1.0.0",
+        "critical": "^1.1.0",
         "del": "^2.2",
         "gulp": "^3.9",
         "gulp-favicons": "^2.2",


### PR DESCRIPTION
To see if it resolves the critical-CSS problems, this upgrades Critical and Penthouse, which in turn downgrades Puppeteer/Chromium.