### PR TITLE
Downgrade ws

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4475,9 +4475,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
     },
     "ws": {
-      "version": "3.3.3",
+      "version": "3.3.2",
       "from": "ws@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz"
     },
     "xdg-basedir": {
       "version": "2.0.0",


### PR DESCRIPTION
Current critical CSS issues seem to be caused by https://github.com/websockets/ws/issues/1256 (the library had been updated in #810).