### PR TITLE
Updated elife/patterns to 2e725e4: Move PatternExtension from elife/journal to elife/patterns

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -961,12 +961,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "bd4b8bfb40bde90f5c669b240d37fc2afcff3556"
+                "reference": "2e725e48980940250bbb76ca3c9d79b87ba5075d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/bd4b8bfb40bde90f5c669b240d37fc2afcff3556",
-                "reference": "bd4b8bfb40bde90f5c669b240d37fc2afcff3556",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/2e725e48980940250bbb76ca3c9d79b87ba5075d",
+                "reference": "2e725e48980940250bbb76ca3c9d79b87ba5075d",
                 "shasum": ""
             },
             "require": {
@@ -983,7 +983,11 @@
                 "symfony/filesystem": "^3.0",
                 "symfony/finder": "^3.0",
                 "symfony/process": "^3.0",
-                "symfony/yaml": "^3.1"
+                "symfony/yaml": "^3.1",
+                "twig/twig": "^2.0"
+            },
+            "suggest": {
+                "twig/twig": "^2.0, to use PatternExtension"
             },
             "type": "library",
             "autoload": {
@@ -999,7 +1003,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-01-29T13:00:13+00:00"
+            "time": "2018-01-30T11:26:19+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies-journal-update-patterns-php/311/display/redirect which resulted in this pull request.