### PR TITLE
Hard-code firewall name

### DIFF
--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -18,8 +18,7 @@ final class AuthController extends Controller
         }
 
         if ($referer = trim($request->headers->get('Referer'))) {
-            $firewall = $this->get('security.firewall.map')->getFirewallConfig($request);
-            $this->saveTargetPath($request->getSession(), $firewall->getName(), $referer);
+            $this->saveTargetPath($request->getSession(), 'main', $referer);
         }
 
         return $this->get('oauth2.registry')


### PR DESCRIPTION
#824 got through to production and broke the log-in page. Rather than be smart about trying to work out the firewall name, let's just hard-code it.