### PR TITLE
Fix view selector when Hypothesis is enabled

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -852,13 +852,13 @@ final class ArticlesController extends Controller
 
                 return new ViewSelector(
                     $this->generateTextPath($history, $item->getVersion()),
-                    array_filter(array_map(function (ViewModel $viewModel) {
+                    array_values(array_filter(array_map(function (ViewModel $viewModel) {
                         if ($viewModel instanceof ArticleSection) {
                             return new Link($viewModel['title'], '#'.$viewModel['id']);
                         }
 
                         return null;
-                    }, $sections)),
+                    }, $sections))),
                     $hasFigures ? $this->generateFiguresPath($history, $item->getVersion()) : null,
                     $isFiguresPage,
                     $item instanceof ArticleVoR

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1309,6 +1309,14 @@ final class ArticleControllerTest extends PageTestCase
 
         $this->assertNotContains('Comments', $crawler->text());
         $this->assertContains('Annotations', $crawler->filter('.contextual-data__list')->text());
+
+        $this->assertSame(
+            [
+                'Introduction',
+                'Article information',
+            ],
+            array_map('trim', $crawler->filter('.view-selector__jump_link_item')->extract('_text'))
+        );
     }
 
     /**


### PR DESCRIPTION
First visible when #801 made the speech bubble part of the list of content (the `array_filter()` already existed, but I don't think it was ever used). Seems like the Mustache engine doesn't like associative arrays (since this is now missing keys).

Maybe we should always use `array_values()` inside every view model where the pattern wants an array rather than an object. /cc @davidcmoulton.