### PR TITLE
Use the log-out page if a user's profile can't be loaded

### DIFF
--- a/test/Controller/AuthenticationTest.php
+++ b/test/Controller/AuthenticationTest.php
@@ -289,6 +289,10 @@ final class AuthenticationTest extends WebTestCase
 
         $client->request('GET', '/');
 
+        $this->assertTrue($client->getResponse()->isRedirect('http://localhost/log-out'));
+
+        $client->followRedirect();
+
         $this->assertTrue($client->getResponse()->isRedirect('http://localhost/'));
 
         $crawler = $client->followRedirect();


### PR DESCRIPTION
Extracted from #852.

Bit of an older post, but https://stackoverflow.com/a/6474975/77199 suggests that we do need to `$this->get('security.token_storage')->setToken(null);` (which had been causing a test failure, but not real-world failures). Rather than worry about all that, given this is an edge-case (Profiles is broken and it's not in the cache) let's just redirect the user to the log out page instead.