### PR TITLE
ELPP-3437 Fix related item text when articles are related

### DIFF
--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -143,18 +143,15 @@ final class ArticlesController extends Controller
                 }
 
                 if ($relatedItem instanceof Article) {
-                    $unrelated = true;
                     foreach ($relatedArticles as $relatedArticle) {
                         if ($relatedArticle->getId() === $relatedItem->getId()) {
-                            $unrelated = false;
+                            $related = true;
                             break;
                         }
                     }
-                } else {
-                    $unrelated = false;
                 }
 
-                $item = $this->convertTo($relatedItem, ViewModel\Teaser::class, ['variant' => 'relatedItem', 'from' => $item->getType(), 'unrelated' => $unrelated]);
+                $item = $this->convertTo($relatedItem, ViewModel\Teaser::class, ['variant' => 'relatedItem', 'from' => $item->getType(), 'related' => $related ?? false]);
 
                 if ($listing) {
                     return ViewModel\ListingTeasers::withSeeMore([$item], new ViewModel\SeeMoreLink(new Link('Further reading', '#listing')));

--- a/src/Controller/InterviewsController.php
+++ b/src/Controller/InterviewsController.php
@@ -116,7 +116,7 @@ final class InterviewsController extends Controller
         $arguments['collections'] = $this->get('elife.api_sdk.collections')
             ->containing(Identifier::interview($id))
             ->slice(0, 10)
-            ->map($this->willConvertTo(Teaser::class, ['variant' => 'relatedItem', 'from' => 'interview', 'unrelated' => false]))
+            ->map($this->willConvertTo(Teaser::class, ['variant' => 'relatedItem', 'from' => 'interview', 'related' => true]))
             ->then(Callback::emptyOr(function (Sequence $collections) {
                 return ListingTeasers::basic($collections->toArray());
             }))

--- a/src/Helper/ModelRelationship.php
+++ b/src/Helper/ModelRelationship.php
@@ -46,9 +46,9 @@ final class ModelRelationship
     {
     }
 
-    public static function get(string $from, string $to, bool $unrelated = false) : string
+    public static function get(string $from, string $to, bool $related = false) : string
     {
-        if ($unrelated) {
+        if (!$related) {
             return self::$defaultUnrelated;
         }
 

--- a/src/Helper/ModelRelationship.php
+++ b/src/Helper/ModelRelationship.php
@@ -4,7 +4,8 @@ namespace eLife\Journal\Helper;
 
 final class ModelRelationship
 {
-    private static $default = 'Of interest';
+    private static $defaultRelated = 'Related to';
+    private static $defaultUnrelated = 'Of interest';
     private static $fromRelationship = [
         'registered-report' => [
             'to' => [
@@ -48,7 +49,7 @@ final class ModelRelationship
     public static function get(string $from, string $to, bool $unrelated = false) : string
     {
         if ($unrelated) {
-            return self::$default;
+            return self::$defaultUnrelated;
         }
 
         if (!empty(self::$fromRelationship[$from])) {
@@ -60,7 +61,7 @@ final class ModelRelationship
                 return self::$fromRelationship[$from]['text'];
             }
 
-            return self::$default;
+            return self::$defaultRelated;
         }
 
         if (!empty(self::$toRelationship[$to])) {
@@ -72,9 +73,9 @@ final class ModelRelationship
                 return self::$toRelationship[$to]['text'];
             }
 
-            return self::$default;
+            return self::$defaultRelated;
         }
 
-        return self::$default;
+        return self::$defaultRelated;
     }
 }

--- a/src/ViewModel/Converter/ArticleRelatedItemTeaserConverter.php
+++ b/src/ViewModel/Converter/ArticleRelatedItemTeaserConverter.php
@@ -41,7 +41,7 @@ final class ArticleRelatedItemTeaserConverter implements ViewModelConverter
             $object->getFullTitle(),
             $this->urlGenerator->generate('article', [$object]),
             $object->getAuthorLine(),
-            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], $object->getType(), $context['unrelated'] ?? true))),
+            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], $object->getType(), $context['related'] ?? false))),
             $image,
             TeaserFooter::forNonArticle(
                 Meta::withLink(

--- a/src/ViewModel/Converter/CollectionRelatedItemTeaserConverter.php
+++ b/src/ViewModel/Converter/CollectionRelatedItemTeaserConverter.php
@@ -35,7 +35,7 @@ final class CollectionRelatedItemTeaserConverter implements ViewModelConverter
             $object->getTitle(),
             $this->urlGenerator->generate('collection', [$object]),
             $curatedBy,
-            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], 'collection', $context['unrelated'] ?? true))),
+            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], 'collection', $context['related'] ?? false))),
             $this->smallTeaserImage($object),
             ViewModel\TeaserFooter::forNonArticle(
                 ViewModel\Meta::withLink(

--- a/src/ViewModel/Converter/ExternalArticleRelatedItemTeaserConverter.php
+++ b/src/ViewModel/Converter/ExternalArticleRelatedItemTeaserConverter.php
@@ -20,7 +20,7 @@ final class ExternalArticleRelatedItemTeaserConverter implements ViewModelConver
             $object->getTitle(),
             $object->getUri(),
             $object->getAuthorLine(),
-            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], $object->getType(), $context['unrelated'] ?? true))),
+            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], $object->getType(), $context['related'] ?? false))),
             null,
             TeaserFooter::forNonArticle(Meta::withText($object->getJournal()))
         );

--- a/src/ViewModel/Converter/PodcastEpisodeChapterRelatedItemTeaserConverter.php
+++ b/src/ViewModel/Converter/PodcastEpisodeChapterRelatedItemTeaserConverter.php
@@ -29,7 +29,7 @@ final class PodcastEpisodeChapterRelatedItemTeaserConverter implements ViewModel
             $chapter->getLongTitle() ?? $chapter->getTitle(),
             $this->urlGenerator->generate('podcast-episode', [$object]),
             null,
-            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], 'podcast-episode-chapter', $context['unrelated'] ?? true))),
+            new ViewModel\ContextLabel(new ViewModel\Link(ModelRelationship::get($context['from'], 'podcast-episode-chapter', $context['related'] ?? false))),
             null,
             TeaserFooter::forNonArticle(
                 ViewModel\Meta::withLink(

--- a/test/Helper/ModelRelationshipTest.php
+++ b/test/Helper/ModelRelationshipTest.php
@@ -20,15 +20,16 @@ final class ModelRelationshipTest extends TestCase
     public function typesProvider() : Traversable
     {
         yield ['foo', 'bar', true, 'Of interest'];
-        yield ['foo', 'bar', false, 'Of interest'];
+        yield ['foo', 'bar', false, 'Related to'];
 
         yield ['registered-report', 'external-article', false, 'Original article'];
         yield ['registered-report', 'external-article', true, 'Of interest'];
-        yield ['registered-report', 'research-article', false, 'Of interest'];
+        yield ['registered-report', 'research-article', false, 'Related to'];
 
         yield ['research-advance', 'research-article', false, 'Builds upon'];
         yield ['research-advance', 'research-article', true, 'Of interest'];
         yield ['research-advance', 'correction', true, 'Of interest'];
+        yield ['research-advance', 'correction', false, 'Related to'];
 
         yield ['research-article', 'collection', false, 'Part of'];
         yield ['correction', 'collection', false, 'Part of'];
@@ -41,5 +42,6 @@ final class ModelRelationshipTest extends TestCase
         yield ['research-article', 'research-advance', false, 'Built upon by'];
         yield ['research-article', 'research-advance', true, 'Of interest'];
         yield ['correction', 'research-advance', true, 'Of interest'];
+        yield ['correction', 'research-advance', false, 'Related to'];
     }
 }

--- a/test/Helper/ModelRelationshipTest.php
+++ b/test/Helper/ModelRelationshipTest.php
@@ -12,36 +12,36 @@ final class ModelRelationshipTest extends TestCase
      * @test
      * @dataProvider typesProvider
      */
-    public function it_determines_relationship_text(string $from, string $to, bool $unrelated, string $expected)
+    public function it_determines_relationship_text(string $from, string $to, bool $related, string $expected)
     {
-        $this->assertSame($expected, ModelRelationship::get($from, $to, $unrelated));
+        $this->assertSame($expected, ModelRelationship::get($from, $to, $related));
     }
 
     public function typesProvider() : Traversable
     {
-        yield ['foo', 'bar', true, 'Of interest'];
-        yield ['foo', 'bar', false, 'Related to'];
+        yield ['foo', 'bar', false, 'Of interest'];
+        yield ['foo', 'bar', true, 'Related to'];
 
-        yield ['registered-report', 'external-article', false, 'Original article'];
-        yield ['registered-report', 'external-article', true, 'Of interest'];
-        yield ['registered-report', 'research-article', false, 'Related to'];
+        yield ['registered-report', 'external-article', true, 'Original article'];
+        yield ['registered-report', 'external-article', false, 'Of interest'];
+        yield ['registered-report', 'research-article', true, 'Related to'];
 
-        yield ['research-advance', 'research-article', false, 'Builds upon'];
-        yield ['research-advance', 'research-article', true, 'Of interest'];
-        yield ['research-advance', 'correction', true, 'Of interest'];
-        yield ['research-advance', 'correction', false, 'Related to'];
+        yield ['research-advance', 'research-article', true, 'Builds upon'];
+        yield ['research-advance', 'research-article', false, 'Of interest'];
+        yield ['research-advance', 'correction', false, 'Of interest'];
+        yield ['research-advance', 'correction', true, 'Related to'];
 
-        yield ['research-article', 'collection', false, 'Part of'];
-        yield ['correction', 'collection', false, 'Part of'];
-        yield ['research-article', 'collection', true, 'Of interest'];
+        yield ['research-article', 'collection', true, 'Part of'];
+        yield ['correction', 'collection', true, 'Part of'];
+        yield ['research-article', 'collection', false, 'Of interest'];
 
-        yield ['research-article', 'podcast-episode-chapter', false, 'Discussed in'];
-        yield ['correction', 'podcast-episode-chapter', false, 'Discussed in'];
-        yield ['research-article', 'podcast-episode-chapter', true, 'Of interest'];
+        yield ['research-article', 'podcast-episode-chapter', true, 'Discussed in'];
+        yield ['correction', 'podcast-episode-chapter', true, 'Discussed in'];
+        yield ['research-article', 'podcast-episode-chapter', false, 'Of interest'];
 
-        yield ['research-article', 'research-advance', false, 'Built upon by'];
-        yield ['research-article', 'research-advance', true, 'Of interest'];
-        yield ['correction', 'research-advance', true, 'Of interest'];
-        yield ['correction', 'research-advance', false, 'Related to'];
+        yield ['research-article', 'research-advance', true, 'Built upon by'];
+        yield ['research-article', 'research-advance', false, 'Of interest'];
+        yield ['correction', 'research-advance', false, 'Of interest'];
+        yield ['correction', 'research-advance', true, 'Related to'];
     }
 }


### PR DESCRIPTION
#867 accidentally switched the default text for when two articles are related to the default _unrelated_ text.

(Probably caused by not having tests before.)