### PR TITLE
ELPP-3447 Return API 504 responses

### DIFF
--- a/src/EventListener/ApiTimeoutSubscriber.php
+++ b/src/EventListener/ApiTimeoutSubscriber.php
@@ -3,6 +3,7 @@
 namespace eLife\Journal\EventListener;
 
 use eLife\ApiClient\Exception\ApiTimeout;
+use eLife\ApiClient\Exception\BadResponse;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -21,7 +22,7 @@ final class ApiTimeoutSubscriber implements EventSubscriberInterface
     {
         $exception = $event->getException();
 
-        if ($exception instanceof ApiTimeout) {
+        if ($exception instanceof ApiTimeout || ($exception instanceof BadResponse && Response::HTTP_GATEWAY_TIMEOUT === $exception->getResponse()->getStatusCode())) {
             $event->setException(new HttpException(Response::HTTP_GATEWAY_TIMEOUT, $exception->getMessage(), $exception));
         }
     }

--- a/test/EventListener/ApiTimeoutSubscriberTest.php
+++ b/test/EventListener/ApiTimeoutSubscriberTest.php
@@ -3,9 +3,11 @@
 namespace test\eLife\Journal\EventListener;
 
 use eLife\ApiClient\Exception\ApiTimeout;
+use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiClient\Exception\NetworkProblem;
 use eLife\Journal\EventListener\ApiTimeoutSubscriber;
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -32,11 +34,41 @@ final class ApiTimeoutSubscriberTest extends TestCase
     /**
      * @test
      */
+    public function it_turns_gateway_timeout_responses_into_a_504_exception()
+    {
+        $subscriber = new ApiTimeoutSubscriber();
+
+        $exception = new BadResponse('Timeout', new GuzzleRequest('GET', 'http://www.example.com/'), new GuzzleResponse(504));
+        $event = new GetResponseForExceptionEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST, $exception);
+
+        $subscriber->onKernelException($event);
+
+        $this->assertEquals(new HttpException(504, 'Timeout', $exception), $event->getException());
+    }
+
+    /**
+     * @test
+     */
     public function it_ignores_other_exceptions()
     {
         $subscriber = new ApiTimeoutSubscriber();
 
         $exception = new NetworkProblem('Timeout', new GuzzleRequest('GET', 'http://www.example.com/'));
+        $event = new GetResponseForExceptionEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST, $exception);
+
+        $subscriber->onKernelException($event);
+
+        $this->assertSame($exception, $event->getException());
+    }
+
+    /**
+     * @test
+     */
+    public function it_ignores_other_responses()
+    {
+        $subscriber = new ApiTimeoutSubscriber();
+
+        $exception = new BadResponse('Timeout', new GuzzleRequest('GET', 'http://www.example.com/'), new GuzzleResponse(503));
         $event = new GetResponseForExceptionEvent($this->createMock(HttpKernelInterface::class), new Request(), HttpKernelInterface::MASTER_REQUEST, $exception);
 
         $subscriber->onKernelException($event);


### PR DESCRIPTION
Currently cURL timeouts are turned into 504 responses, but a 504 response from the API becomes a 500. This keeps it as a 504 (which allows Spectrum to retry).