### PR TITLE
Updated elife/patterns to b9d6192: Correct downstream pipelines names to reflect their new folder

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -961,12 +961,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "3d03769c616c2bf141b5a56b2d5e2a35ca4b3bc4"
+                "reference": "b9d619285c0bb83fe827f5fa5994ad9e664dc376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/3d03769c616c2bf141b5a56b2d5e2a35ca4b3bc4",
-                "reference": "3d03769c616c2bf141b5a56b2d5e2a35ca4b3bc4",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/b9d619285c0bb83fe827f5fa5994ad9e664dc376",
+                "reference": "b9d619285c0bb83fe827f5fa5994ad9e664dc376",
                 "shasum": ""
             },
             "require": {
@@ -1003,7 +1003,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-02-12T10:17:59+00:00"
+            "time": "2018-02-14T15:39:12+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/320/display/redirect which resulted in this pull request.