### PR TITLE
Fix nested title levels

### DIFF
--- a/src/Helper/CanConvertContent.php
+++ b/src/Helper/CanConvertContent.php
@@ -18,6 +18,6 @@ trait CanConvertContent
 
     final protected function convertContent(HasContent $object, int $level = 2, array $context = []) : Sequence
     {
-        return $object->getContent()->map($this->willConvertTo(null, $context + ['level' => $level]));
+        return $object->getContent()->map($this->willConvertTo(null, ['level' => $level] + $context));
     }
 }


### PR DESCRIPTION
https://elifesciences.org/articles/01948#s2-3-2-2-1 should be a `<h6>`, but the different levels get stuck as a `<h3>`.