### PR TITLE
Forcibly clear cache if test isn't using debug mode

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -5,9 +5,6 @@ rm -f build/*.xml
 
 export SYMFONY_ENV=test
 
-echo "cache:clear"
-bin/console cache:clear --no-warmup
-
 echo "security:check"
 bin/console security:check
 

--- a/test/AppKernelTestCase.php
+++ b/test/AppKernelTestCase.php
@@ -24,6 +24,17 @@ trait AppKernelTestCase
         return static::$kernel;
     }
 
+    protected static function createKernel(array $options = [])
+    {
+        $kernel = parent::createKernel($options);
+
+        if (!$kernel->isDebug()) {
+            (new Filesystem())->remove($kernel->getCacheDir());
+        }
+
+        return $kernel;
+    }
+
     final protected static function mockApiResponse(RequestInterface $request, ResponseInterface $response)
     {
         static::$kernel->getContainer()

--- a/test/AppKernelTestCase.php
+++ b/test/AppKernelTestCase.php
@@ -24,7 +24,7 @@ trait AppKernelTestCase
         return static::$kernel;
     }
 
-    protected static function createKernel(array $options = [])
+    final protected static function createKernel(array $options = [])
     {
         $kernel = parent::createKernel($options);
 


### PR DESCRIPTION
https://github.com/elifesciences/journal/blob/6f4a523ce29c1068f8e98f5c7845b3d9f6038d0e/test/Controller/ExceptionControllerTest.php#L9-L20

requires not using `debug` mode to check the production exception page, but it means that the cache has to be cleared before running to make sure it's using a fresh container (a service/class disappearing will break the test otherwise). Rather than rely on the test script doing it beforehand, we can recognise the case and force it (avoids the problem happening locally too). 