### PR TITLE
Make sure rewritten subject exists in search results

### DIFF
--- a/src/Guzzle/SubjectRewritingMiddleware.php
+++ b/src/Guzzle/SubjectRewritingMiddleware.php
@@ -191,9 +191,10 @@ final class SubjectRewritingMiddleware
                 foreach ($subjects as $i => $subject) {
                     if ($replacement['id'] === $subject['id']) {
                         $subjects[$i]['results'] += $total;
-                        break;
+                        continue 2;
                     }
                 }
+                $subjects[] = $replacement + ['results' => $total];
             }
         }
 

--- a/src/Guzzle/SubjectRewritingMiddleware.php
+++ b/src/Guzzle/SubjectRewritingMiddleware.php
@@ -188,17 +188,26 @@ final class SubjectRewritingMiddleware
                 }
             }
             if ($total > 0) {
-                foreach ($subjects as $i => $subject) {
-                    if ($replacement['id'] === $subject['id']) {
-                        $subjects[$i]['results'] += $total;
-                        continue 2;
-                    }
-                }
-                $subjects[] = $replacement + ['results' => $total];
+                $subjects = $this->ensureSearchSubject($subjects, $replacement, $total);
             }
         }
 
         return array_values($subjects);
+    }
+
+    private function ensureSearchSubject(array $subjects, array $subject, int $total) : array
+    {
+        foreach ($subjects as $i => $existingSubject) {
+            if ($subject['id'] === $existingSubject['id']) {
+                $subjects[$i]['results'] += $total;
+
+                return $subjects;
+            }
+        }
+
+        $subjects[] = $subject + ['results' => $total];
+
+        return $subjects;
     }
 
     private function updateSubjects(array $subjects) : array

--- a/test/Guzzle/SubjectRewritingMiddlewareTest.php
+++ b/test/Guzzle/SubjectRewritingMiddlewareTest.php
@@ -324,7 +324,7 @@ final class SubjectRewritingMiddlewareTest extends KernelTestCase
                     ],
                 ],
             ],
-            'application/vnd.elife.search+json; version=1' => [
+            'application/vnd.elife.search+json; version=1; with new subject' => [
                 [
                     'total' => 2,
                     'items' => [
@@ -365,6 +365,68 @@ final class SubjectRewritingMiddlewareTest extends KernelTestCase
                     'subjects' => [
                         $this->createSubject('new-subject', 'New Subject') + ['results' => 6],
                         $this->createSubject('other-subject', 'Other Subject') + ['results' => 8],
+                    ],
+                    'types' => [
+                        'correction' => 0,
+                        'editorial' => 0,
+                        'feature' => 0,
+                        'insight' => 0,
+                        'research-advance' => 0,
+                        'research-article' => 2,
+                        'retraction' => 0,
+                        'registered-report' => 0,
+                        'replication-study' => 0,
+                        'scientific-correspondence' => 0,
+                        'short-report' => 0,
+                        'tools-resources' => 0,
+                        'blog-article' => 0,
+                        'collection' => 0,
+                        'interview' => 0,
+                        'labs-post' => 0,
+                        'podcast-episode' => 0,
+                    ],
+                ],
+            ],
+            'application/vnd.elife.search+json; version=1; without new subject' => [
+                [
+                    'total' => 2,
+                    'items' => [
+                        $this->createArticlePoA(false),
+                        $this->createArticleVoR(false),
+                    ],
+                    'subjects' => [
+                        $this->createSubject('old-subject', 'Old Subject') + ['results' => 2],
+                        $this->createSubject('other-subject', 'Other Subject') + ['results' => 8],
+                    ],
+                    'types' => [
+                        'correction' => 0,
+                        'editorial' => 0,
+                        'feature' => 0,
+                        'insight' => 0,
+                        'research-advance' => 0,
+                        'research-article' => 2,
+                        'retraction' => 0,
+                        'registered-report' => 0,
+                        'replication-study' => 0,
+                        'scientific-correspondence' => 0,
+                        'short-report' => 0,
+                        'tools-resources' => 0,
+                        'blog-article' => 0,
+                        'collection' => 0,
+                        'interview' => 0,
+                        'labs-post' => 0,
+                        'podcast-episode' => 0,
+                    ],
+                ],
+                [
+                    'total' => 2,
+                    'items' => [
+                        $this->createArticlePoA(true),
+                        $this->createArticleVoR(true),
+                    ],
+                    'subjects' => [
+                        $this->createSubject('other-subject', 'Other Subject') + ['results' => 8],
+                        $this->createSubject('new-subject', 'New Subject') + ['results' => 2],
                     ],
                     'types' => [
                         'correction' => 0,


### PR DESCRIPTION
It disappears when content has been migrated over, so we'll need to add it.