### PR TITLE
ELPP-3499 Only apply FragmentHandler to article text pages with a ViewSelector

### DIFF
--- a/app/Resources/views/article-text.html.twig
+++ b/app/Resources/views/article-text.html.twig
@@ -18,6 +18,12 @@
 
         {% block main %}
 
+            {% if viewSelector %}
+
+                <div data-behaviour="FragmentHandler">
+
+            {% endif %}
+
             {% if hasFigures %}
 
                 {% fragment_link_rewrite figuresPath %}
@@ -37,6 +43,13 @@
                     {{ render_pattern(part) }}
 
                 {% endfor %}
+
+            {% endif %}
+
+
+            {% if viewSelector %}
+
+            </div>
 
             {% endif %}
 

--- a/app/Resources/views/article-text.html.twig
+++ b/app/Resources/views/article-text.html.twig
@@ -20,7 +20,7 @@
 
             {% if viewSelector %}
 
-                <div data-behaviour="FragmentHandler">
+                <div data-behaviour="FragmentHandler"><div>
 
             {% endif %}
 
@@ -46,12 +46,6 @@
 
             {% endif %}
 
-
-            {% if viewSelector %}
-
-            </div>
-
-            {% endif %}
 
         {% endblock %}
 

--- a/app/Resources/views/article-text.html.twig
+++ b/app/Resources/views/article-text.html.twig
@@ -20,7 +20,7 @@
 
             {% if viewSelector %}
 
-                <div data-behaviour="FragmentHandler"><div>
+                <div data-behaviour="FragmentHandler"></div>
 
             {% endif %}
 

--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -212,7 +212,7 @@
         </noscript>
     {% endif %}
 
-    <div class="global-wrapper" data-behaviour="FragmentHandler Math{% if hypothesis ?? false %} HypothesisLoader{% endif %}"
+    <div class="global-wrapper" data-behaviour="Math{% if hypothesis ?? false %} HypothesisLoader{% endif %}"
         {% if item is defined and item is not null %}
             data-item-type="{% if item.type is defined %}{{ item.type }}{% else %}{{ item.identifier.type }}{% endif %}"
         {% endif %}


### PR DESCRIPTION
The FragmentHandler is currently present on every page via https://github.com/elifesciences/journal/blob/develop/app/Resources/views/page.html.twig#L215

The aim of this PR is to only apply the FragmentHandler JavaScript behaviour when the page contains collapsible sections. This implementation uses the presence of a view selector on an article's text view (as opposed to figures etc view) as a proxy for the presence of collapsible article sections.