### PR TITLE
Updated elife/patterns to 95fe655: Updated pattern-library to 940d3a6: Only use CSS grid when grid gap property is supported

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -961,12 +961,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "aabd017eb100c38834b3cd0f9e326c67dd41ccec"
+                "reference": "95fe65560d8b6145fe120fc7fbeceff35d089493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/aabd017eb100c38834b3cd0f9e326c67dd41ccec",
-                "reference": "aabd017eb100c38834b3cd0f9e326c67dd41ccec",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/95fe65560d8b6145fe120fc7fbeceff35d089493",
+                "reference": "95fe65560d8b6145fe120fc7fbeceff35d089493",
                 "shasum": ""
             },
             "require": {
@@ -1003,7 +1003,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-03-13T07:55:13+00:00"
+            "time": "2018-03-13T12:47:00+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/338/display/redirect which resulted in this pull request.