### PR TITLE
Updated elife/patterns to 6773648: ELPP-3436: Avoid orphan further reading heading

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -966,12 +966,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "95fe65560d8b6145fe120fc7fbeceff35d089493"
+                "reference": "6773648adf7fa658debeae869797eb8a4d23d271"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/95fe65560d8b6145fe120fc7fbeceff35d089493",
-                "reference": "95fe65560d8b6145fe120fc7fbeceff35d089493",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/6773648adf7fa658debeae869797eb8a4d23d271",
+                "reference": "6773648adf7fa658debeae869797eb8a4d23d271",
                 "shasum": ""
             },
             "require": {
@@ -1008,7 +1008,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-03-13T12:47:00+00:00"
+            "time": "2018-03-28T09:08:18+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/340/display/redirect which resulted in this pull request.