### PR TITLE
Fix non-deterministic tests

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,5 @@ IMAGE_TAG=develop
 APP_ENV=dev
 PHP_VERSION=2f00bfb3e9385f38997f04cea41ffbd3ff9d10a8
 NODE_VERSION=6.14.2
+# add '-debug' for VNC support
+SELENIUM_IMAGE_SUFFIX=

--- a/Dockerfile.selenium
+++ b/Dockerfile.selenium
@@ -1,9 +1,0 @@
-FROM selenium/standalone-firefox:2.53.0
-
-USER root
-RUN apt-get update && apt-get install -y \
-    linux-sound-base \
-    mplayer \
-    && rm -rf /var/lib/apt/lists/*
-
-USER seluser

--- a/README.md
+++ b/README.md
@@ -29,3 +29,11 @@ Running the tests
 -----------------
 
 `docker-compose run cli vendor/bin/phpunit`
+
+Reproduce a ci failure
+----------------------
+
+```
+SELENIUM_IMAGE_SUFFIX=-debug docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --build -V
+docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci .ci/behat
+```

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -6,6 +6,7 @@ default:
                     symfony2: ~
                 javascript:
                     selenium2:
+                        browser: chrome
                         wd_host: http://selenium:4444/wd/hub
             base_url: http://web/
         Behat\Symfony2Extension:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,10 +14,7 @@ services:
         image: elifesciences/journal_composer_dev:${IMAGE_TAG}
         command: /bin/bash
     selenium:
-        build:
-            context: .
-            dockerfile: Dockerfile.selenium
-        image: elifesciences/journal_selenium:${IMAGE_TAG}
+        image: selenium/standalone-chrome:2.53.1
         volumes:
             - /dev/shm:/dev/shm
     cli:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -14,7 +14,10 @@ services:
         image: elifesciences/journal_composer_dev:${IMAGE_TAG}
         command: /bin/bash
     selenium:
-        image: selenium/standalone-chrome:2.53.1
+        image: selenium/standalone-chrome${SELENIUM_IMAGE_SUFFIX}:2.53.1
+        ports:
+            - "4444:4444" # http://localhost:4444/wd/hub/static/resource/hub.html
+            - "5900:5900" # VNC connection for debug images
         volumes:
             - /dev/shm:/dev/shm
     cli:

--- a/features/bootstrap/Context.php
+++ b/features/bootstrap/Context.php
@@ -55,6 +55,14 @@ abstract class Context extends RawMinkContext implements KernelAwareContext
     /**
      * @BeforeScenario
      */
+    final public function clearHttpCache()
+    {
+        $this->kernel->getContainer()->get('cache.guzzle')->clear();
+    }
+
+    /**
+     * @BeforeScenario
+     */
     final public function resetEmails()
     {
         $this->emails = [];

--- a/features/bootstrap/HomepageContext.php
+++ b/features/bootstrap/HomepageContext.php
@@ -634,7 +634,9 @@ final class HomepageContext extends Context
      */
     public function iShouldSeeTheCoverInTheCarousel(string $name)
     {
-        $this->assertSession()->elementAttributeContains('css', '.carousel-item__title_link', 'href', $this->createId($name));
+        $this->spin(function () use ($name) {
+            $this->assertSession()->elementAttributeContains('css', '.carousel-item__title_link', 'href', $this->createId($name));
+        });
     }
 
     /**

--- a/src/DependencyInjection/HttpCachePass.php
+++ b/src/DependencyInjection/HttpCachePass.php
@@ -16,7 +16,7 @@ final class HttpCachePass implements CompilerPassInterface
 
         $tags = $definition->getTags();
 
-        $namespace = crc32(implode(',', array_map(Versions::class.'::getVersion', self::$packages)));
+        $namespace = crc32(implode(',', [$container->getParameter('kernel.instance')] + array_map(Versions::class.'::getVersion', self::$packages)));
 
         // Make updates to a library invalidate the cache.
         $tags['cache.pool'][0]['namespace'] = "http-$namespace";


### PR DESCRIPTION
#940 saw Redis used for caching rather than the filesystem, but without isolation leading to conflicts in tests. Rather than turn off Redis, this adds the kernel's instance (eg `behat1`, `phpunit2`) to the namespace.