### PR TITLE
ELPP-3393 Reintroduce smoke tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,11 @@ elifePipeline {
                         'cli': './smoke_tests_cli.sh',
                         'fpm': './smoke_tests_fpm.sh',
                     ],
+                    'blackbox': [
+                        './smoke_tests.sh localhost 8080',
+                    ]
                 ])
 
-                sh "./smoke_tests.sh localhost 8080"
             }
         },
         'containers--medium'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ elifePipeline {
                 ])
 
                 dockerComposeSmokeTests('profiles', commit, [
-                    'scripts': [
+                    'services': [
                         'cli': './smoke_tests_cli.sh',
                         'fpm': './smoke_tests_fpm.sh',
                     ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,8 @@ elifePipeline {
                         'fpm': './smoke_tests_fpm.sh',
                     ],
                 ])
+
+                sh "./smoke_tests.sh localhost 8080"
             }
         },
         'containers--medium'

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -10,14 +10,14 @@ if docker container ls | grep journal_fpm_1; then
 fi
 
 function from_manifest {
-    cat build/rev-manifest.json | jq -r ".[\"${1}\"]"
+    jq -r ".[\"${1}\"]" < build/rev-manifest.json
 }
 
-smoke_url_ok $hostname:$port/favicon.ico
-smoke_url_ok $hostname:$port/$(from_manifest assets/favicons/manifest.json)
-smoke_url_ok $hostname:$port/$(from_manifest assets/patterns/css/all.css)
-smoke_url_ok $hostname:$port/$(from_manifest assets/images/banners/magazine-1114x336@1.jpg)
-smoke_url_ok $hostname:$port/ping
+smoke_url_ok "$hostname:$port/favicon.ico"
+smoke_url_ok "$hostname:$port/$(from_manifest assets/favicons/manifest.json)"
+smoke_url_ok "$hostname:$port/$(from_manifest assets/patterns/css/all.css)"
+smoke_url_ok "$hostname:$port/$(from_manifest assets/images/banners/magazine-1114x336@1.jpg)"
+smoke_url_ok "$hostname:$port/ping"
     smoke_assert_body "pong"
 
 if [ "$ENVIRONMENT_NAME" != "ci" ] && [ "$ENVIRONMENT_NAME" != "dev" ]
@@ -25,7 +25,7 @@ if [ "$ENVIRONMENT_NAME" != "ci" ] && [ "$ENVIRONMENT_NAME" != "dev" ]
     set -e
     retry "./status_test.sh $hostname $port" 2
     set +e
-    smoke_url_ok $hostname:$port/
+    smoke_url_ok "$hostname:$port/"
 fi
 
 smoke_report

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -20,7 +20,7 @@ smoke_url_ok $hostname:$port/$(from_manifest assets/images/banners/magazine-1114
 smoke_url_ok $hostname:$port/ping
     smoke_assert_body "pong"
 
-if [ "$ENVIRONMENT_NAME" != "ci" && "$ENVIRONMENT_NAME" != "dev" ]
+if [ "$ENVIRONMENT_NAME" != "ci" ] && [ "$ENVIRONMENT_NAME" != "dev" ]
   then
     set -e
     retry "./status_test.sh $hostname $port" 2

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -6,7 +6,7 @@ port="${2:-80}"
 
 # retrieve manifest from container, if present
 if docker container ls | grep journal_assets_1; then
-    docker cp journal_assets_1:/srv/journal/build/rev-manifest.json build/
+    docker cp journal_assets_1:/build/rev-manifest.json build/
 fi
 
 function from_manifest {

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -20,7 +20,7 @@ smoke_url_ok $hostname:$port/$(from_manifest assets/images/banners/magazine-1114
 smoke_url_ok $hostname:$port/ping
     smoke_assert_body "pong"
 
-if [ "$ENVIRONMENT_NAME" != "dev" ]
+if [ "$ENVIRONMENT_NAME" != "ci" && "$ENVIRONMENT_NAME" != "dev" ]
   then
     set -e
     retry "./status_test.sh $hostname $port" 2

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -5,7 +5,7 @@ hostname="${1:-$(hostname)}"
 port="${2:-80}"
 
 # retrieve manifest from container, if present
-if docker container ls | grep journal_assets_1; then
+if docker container ls -a | grep journal_assets_1; then
     docker cp journal_assets_1:/build/rev-manifest.json build/
 fi
 

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -5,8 +5,8 @@ hostname="${1:-$(hostname)}"
 port="${2:-80}"
 
 # retrieve manifest from container, if present
-if docker container ls | grep journal_fpm_1; then
-    docker cp journal_fpm_1:/srv/journal/build/rev-manifest.json build/
+if docker container ls | grep journal_assets_1; then
+    docker cp journal_assets_1:/srv/journal/build/rev-manifest.json build/
 fi
 
 function from_manifest {

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+. /opt/smoke.sh/smoke.sh
+
+function from_manifest {
+    cat build/rev-manifest.json | jq -r ".[\"${1}\"]"
+}
+
+bin/console --version --env=$ENVIRONMENT_NAME
+
+smoke_url_ok $(hostname)/favicon.ico
+smoke_url_ok $(hostname)/$(from_manifest assets/favicons/manifest.json)
+smoke_url_ok $(hostname)/$(from_manifest assets/patterns/css/all.css)
+smoke_url_ok $(hostname)/$(from_manifest assets/images/banners/magazine-1114x336@1.jpg)
+smoke_url_ok $(hostname)/ping
+    smoke_assert_body "pong"
+
+if [ "$ENVIRONMENT_NAME" != "dev" ]
+  then
+    retry ./status_test.sh 2
+    smoke_url_ok $(hostname)/
+fi
+
+smoke_report

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
 . /opt/smoke.sh/smoke.sh
 
+hostname="${1:-$(hostname)}"
+port="${2:-80}"
+
+# retrieve manifest from container, if present
+if docker container ls | grep journal_fpm_1; then
+    docker cp journal_fpm_1:/srv/journal/build/rev-manifest.json build/
+fi
+
 function from_manifest {
     cat build/rev-manifest.json | jq -r ".[\"${1}\"]"
 }
 
-bin/console --version --env=$ENVIRONMENT_NAME
-
-smoke_url_ok $(hostname)/favicon.ico
-smoke_url_ok $(hostname)/$(from_manifest assets/favicons/manifest.json)
-smoke_url_ok $(hostname)/$(from_manifest assets/patterns/css/all.css)
-smoke_url_ok $(hostname)/$(from_manifest assets/images/banners/magazine-1114x336@1.jpg)
-smoke_url_ok $(hostname)/ping
+smoke_url_ok $hostname:$port/favicon.ico
+smoke_url_ok $hostname:$port/$(from_manifest assets/favicons/manifest.json)
+smoke_url_ok $hostname:$port/$(from_manifest assets/patterns/css/all.css)
+smoke_url_ok $hostname:$port/$(from_manifest assets/images/banners/magazine-1114x336@1.jpg)
+smoke_url_ok $hostname:$port/ping
     smoke_assert_body "pong"
 
 if [ "$ENVIRONMENT_NAME" != "dev" ]
   then
-    retry ./status_test.sh 2
-    smoke_url_ok $(hostname)/
+    set -e
+    retry "./status_test.sh $hostname $port" 2
+    set +e
+    smoke_url_ok $hostname:$port/
 fi
 
 smoke_report

--- a/status_test.sh
+++ b/status_test.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 . /opt/smoke.sh/smoke.sh
 
-checks=$(curl -v $(hostname)/status | grep check__name)
+hostname="${1:-$(hostname)}"
+port="${2:-80}"
+
+checks=$(curl -v $hostname:$port/status | grep check__name)
 echo $checks
 good_checks=$(echo $checks | grep -o ✔ | wc -l)
 bad_checks=$(echo $checks | grep -o ✘ | wc -l)

--- a/status_test.sh
+++ b/status_test.sh
@@ -4,10 +4,10 @@
 hostname="${1:-$(hostname)}"
 port="${2:-80}"
 
-checks=$(curl -v $hostname:$port/status | grep check__name)
-echo $checks
-good_checks=$(echo $checks | grep -o ✔ | wc -l)
-bad_checks=$(echo $checks | grep -o ✘ | wc -l)
+checks=$(curl -v "$hostname:$port/status" | grep check__name)
+echo "$checks"
+good_checks=$(echo "$checks" | grep -o ✔ | wc -l)
+bad_checks=$(echo "$checks" | grep -o ✘ | wc -l)
 if [ "$bad_checks" -ne 0 ]; then
     echo "Not all status checks are ok"
     exit 2


### PR DESCRIPTION
The `ci` environment does not use these anymore, but deploys to end2end, continuumtest and production are currently uncovered.