### PR TITLE
Revise build time Docker dependencies

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -37,6 +37,7 @@ services:
         environment:
             - APP_ENV=ci
         depends_on:
+            - composer-dev
             - cli
             - selenium
     fpm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
         image: elifesciences/journal_assets:${IMAGE_TAG}
         depends_on:
             - cli
-            - composer
             - npm
     fpm:
         build:


### PR DESCRIPTION
- Remove implied dependency (`assets` depends already on `cli`, which depends on `composer`)
- Add missing dependency from `ci` to `composer-dev` (causing failures such as in #980)
