### PR TITLE
Updated elife/patterns to 9d4c16a: Updated pattern-library to 427037b: Prevent popup link's default behaviour & propagation if href ends in #

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -910,12 +910,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "37a93ab931e37a7d50a8137cd7a2ec0b5b5d740f"
+                "reference": "9d4c16acc3f3610d0738e021acac4a79aa0b8554"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/37a93ab931e37a7d50a8137cd7a2ec0b5b5d740f",
-                "reference": "37a93ab931e37a7d50a8137cd7a2ec0b5b5d740f",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/9d4c16acc3f3610d0738e021acac4a79aa0b8554",
+                "reference": "9d4c16acc3f3610d0738e021acac4a79aa0b8554",
                 "shasum": ""
             },
             "require": {
@@ -951,7 +951,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-06-19T09:23:18+00:00"
+            "time": "2018-06-19T13:42:11+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/379/display/redirect which resulted in this pull request.