### PR TITLE
Avoid using Gulp for the preload file and JS loader

### DIFF
--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -19,8 +19,6 @@ RUN mkdir -p build/critical-css var && \
 COPY --chown=elife:elife smoke_tests_fpm.sh ./
 COPY --chown=elife:elife web/ web/
 COPY --chown=elife:elife app/ app/
-COPY --from=assets --chown=elife:elife /build/assets/patterns/js/elife-loader.js build/assets/patterns/js/
-COPY --from=assets --chown=elife:elife /build/assets/patterns/preload.json build/assets/patterns/
 COPY --from=assets --chown=elife:elife /build/rev-manifest.json build/
 COPY --from=composer --chown=elife:elife /app/vendor/ vendor/
 COPY --chown=elife:elife src/ src/

--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -279,7 +279,7 @@
 
             window.elifeConfig.domain = '{{ app.request.host|split('.')|slice(-2)|join('.') }}';
 
-            {% include '@build/assets/patterns/js/elife-loader.js' %}
+            {% include '@patterns/assets/js/elife-loader.js' %}
 
         </script>
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -136,4 +136,5 @@ twig:
         hypothesis_authority: '%hypothesis_authority%'
     paths:
         '%kernel.project_dir%/build': 'build'
+        '%kernel.project_dir%/vendor/elife/patterns/resources': 'patterns'
     strict_variables: '%kernel.debug%'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -196,7 +196,11 @@ gulp.task('patterns:clean', () => {
 });
 
 gulp.task('patterns', ['patterns:clean'], () => {
-    return gulp.src('./vendor/elife/patterns/resources/assets/**/*')
+    return gulp.src([
+        './vendor/elife/patterns/resources/assets/**/*',
+        '!./vendor/elife/patterns/resources/assets/js/elife-loader.js',
+        '!./vendor/elife/patterns/resources/assets/preload.json',
+    ])
         .pipe(gulp.dest('./build/assets/patterns'));
 });
 
@@ -205,12 +209,7 @@ gulp.task('assets:clean', () => {
 });
 
 gulp.task('assets', ['assets:clean', 'favicons', 'images', 'patterns'], () => {
-    return gulp.src(
-        [
-            './build/assets/**/*.*',
-            '!./build/assets/patterns/js/elife-loader.js',
-            '!./build/assets/patterns/preload.json',
-        ], {base: "./build", follow: true})
+    return gulp.src('./build/assets/**/*.*', {base: "./build", follow: true})
         .pipe(rev.revision({
             includeFilesInManifest: ['.css', '.jpg', '.js', '.json', '.ico', '.png', '.svg', '.webp', '.woff', '.woff2'],
             replaceInExtensions: ['.css', '.js', '.json'],
@@ -357,9 +356,9 @@ const criticalCssConfig = (function () {
             ),
 
             'podcast-episode': global.concat(
-              listing,
-              /.*\.audio-player.*$/,
-              '.media-chapter-listing-item__header_text_link'
+                listing,
+                /.*\.audio-player.*$/,
+                '.media-chapter-listing-item__header_text_link'
             ),
 
             post: global,

--- a/src/DependencyInjection/PreloadPass.php
+++ b/src/DependencyInjection/PreloadPass.php
@@ -2,24 +2,22 @@
 
 namespace eLife\Journal\DependencyInjection;
 
+use ComposerLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use function file_get_contents;
 use function GuzzleHttp\json_decode;
-use function is_readable;
 
 final class PreloadPass implements CompilerPassInterface
 {
-    const FILE = __DIR__.'/../../build/assets/patterns/preload.json';
-
     public function process(ContainerBuilder $container)
     {
-        if (is_readable(self::FILE)) {
-            $container->addResource(new FileResource(self::FILE));
-            $preloads = json_decode(file_get_contents(self::FILE), true);
-        }
+        $file = ComposerLocator::getPath('elife/patterns').'/resources/assets/preload.json';
 
-        $container->setParameter('preload_links', $preloads ?? []);
+        $container->addResource(new FileResource($file));
+        $preloads = json_decode(file_get_contents($file), true);
+
+        $container->setParameter('preload_links', $preloads);
     }
 }


### PR DESCRIPTION
Without using Containers in production there's an ordering problem, as the files are currently created after the site is initialised, so they're not present. They can be read from the source though.