### PR TITLE
Updated elife/patterns to d566aeb: Updated pattern-library to 2b7a651: Force open article sections if the request is from Google

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -910,12 +910,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "613cc89ea49f54f5f91b0cb9c76f054b1a1b0899"
+                "reference": "d566aebec798347dfa4a4fc75c3ba04fc252bcf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/613cc89ea49f54f5f91b0cb9c76f054b1a1b0899",
-                "reference": "613cc89ea49f54f5f91b0cb9c76f054b1a1b0899",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/d566aebec798347dfa4a4fc75c3ba04fc252bcf2",
+                "reference": "d566aebec798347dfa4a4fc75c3ba04fc252bcf2",
                 "shasum": ""
             },
             "require": {
@@ -951,7 +951,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2018-07-13T11:16:21+00:00"
+            "time": "2018-07-16T11:34:51+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/391/display/redirect which resulted in this pull request.