### PR TITLE
Display annotation highlights always

### DIFF
--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -248,6 +248,7 @@
 
             {% if hypothesis ?? false %}
             window.elifeConfig.hypothesis = {
+              showHighlights: true,
               usernameUrl: '{{ absolute_url(path('profile', {id: 'placeholder'})|replace({'placeholder': ''})) }}',
               services: [{
                 apiUrl: '{{ hypothesis_api }}',


### PR DESCRIPTION
~~We may want to postpone merging this in until after we have introduced css to alter the background colour of highlighted annotations.~~

There will be a followup issue to address the change to background colour.