### PR TITLE
Don't escape GTM IDs

### DIFF
--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -182,7 +182,7 @@
             j.src =
                 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
             f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'gtmDataLayer', '{{ gtm_id }}');
+        })(window, document, 'script', 'gtmDataLayer', '{{ gtm_id|raw }}');
         {% endif %}
     </script>
 
@@ -191,7 +191,7 @@
 {% block content %}
     {% if gtm_id %}
         <noscript>
-            <iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id }}" height="0" width="0"
+            <iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_id|raw }}" height="0" width="0"
                     style="display:none; visibility:hidden"></iframe>
         </noscript>
     {% endif %}


### PR DESCRIPTION
Avoids `foo&amp;bar=baz` if adding extra parameters.