### PR TITLE
Don't delegate abstract's links to popup js

### DIFF
--- a/app/Resources/views/article.html.twig
+++ b/app/Resources/views/article.html.twig
@@ -332,7 +332,7 @@
 
     {% endif %}
 
-    <div data-behaviour="DelegateBehaviour" data-delegate-behaviour="Popup" data-selector="a">
+    <div data-behaviour="DelegateBehaviour" data-delegate-behaviour="Popup" data-selector=".article-section:not(#abstract) a">
 
         {% block article_body %}{% endblock %}
 


### PR DESCRIPTION
Avoid GTM double counting click events within the abstract section of an article.

The way that link clicks are directed to the [`Popup` JavaScript class](https://github.com/elifesciences/pattern-library/blob/develop/assets/js/components/Popup.js) is a blunt instrument (see https://github.com/elifesciences/pattern-library/blob/develop/assets/js/components/DelegateBehaviour.js and https://github.com/elifesciences/journal/blob/develop/app/Resources/views/article.html.twig#L335). In order to determine if a clicked link should be displayed in a popup (for references and authors) it is currently configured to process any click on an anchor element within the article that appears beneath the contextual data pattern (which is most of the article).

This is causing GTM click listeners to fire twice due to the event trapping and subsequent re-issuing of a synthetic click event event within `Popup.js`.

The change in this PR is a pragmatic work around that excludes links within the abstract from this processing.

Longer term, a proper fix should be put in place: `Popup.js` should be improved, and the whole delegated behaviour approach should be re-evaluated. 