### PR TITLE
Add digests to model names list

### DIFF
--- a/src/Helper/ModelName.php
+++ b/src/Helper/ModelName.php
@@ -67,6 +67,10 @@ final class ModelName
             'singular' => 'Collection',
             'plural' => 'Collections',
         ],
+        'digest' => [
+            'singular' => 'Digest',
+            'plural' => 'Digests',
+        ],
         'event' => [
             'singular' => 'Event',
             'plural' => 'Events',

--- a/test/Helper/ModelNameTest.php
+++ b/test/Helper/ModelNameTest.php
@@ -48,6 +48,7 @@ final class ModelNameTest extends TestCase
             'tools-resources' => ['Tools and Resources', 'Tools and Resources'],
             'blog-article' => ['Inside eLife', 'Inside eLife'],
             'collection' => ['Collection', 'Collections'],
+            'digest' => ['Digest', 'Digests'],
             'event' => ['Event', 'Events'],
             'labs-post' => ['Labs Post', 'Labs Posts'],
             'interview' => ['Interview', 'Interviews'],


### PR DESCRIPTION
Fixes 500 error mentioned in https://github.com/elifesciences/issues/issues/4290#issuecomment-422442139.

(GTM was turned on in `demo` recently.)

Might be better to transform the value and override when necessary.