### PR TITLE
Remove memory limit on dev

### DIFF
--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -1,1 +1,2 @@
+memory_limit = -1
 opcache.validate_timestamps = 1


### PR DESCRIPTION
Current PHPUnit nor Behat can be run on the `app` container as they run out of memory (it's an FPM container so has the low default limit).

This makes it unlimited, which will make it harder to spot leaks when developing.

PHPUnit could be configured with `<ini name="memory_limit" value="-1"/>`, Behat has no equivalent so we'd need a bootstrap file.