### PR TITLE
Remove logs in tests

### DIFF
--- a/app/config/config_ci.yml
+++ b/app/config/config_ci.yml
@@ -29,5 +29,10 @@ framework:
         storage_id: session.storage.mock_file
     test: ~
 
+monolog:
+    handlers:
+        main:
+            type: 'null'
+
 web_profiler:
     toolbar: false


### PR DESCRIPTION
Currently logs when running tests are sent to `stderr`, which makes for a very verbose output. This turns them off (might be better to send them somewhere in the longer term though).