### PR TITLE
Prevent most Symfony deprecation notices

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -17,6 +17,7 @@ security:
                         name: '%session_name%' # https://github.com/symfony/symfony/pull/24018
                 path: /log-out
                 target: /
+            logout_on_user_change: true
     access_control:
         - path: ^/log-in
           roles: IS_AUTHENTICATED_ANONYMOUSLY

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1,5 +1,8 @@
 services:
 
+    _defaults:
+        public: true
+
     elife.api_client.client:
         class: eLife\ApiClient\HttpClient\Guzzle6HttpClient
         arguments:
@@ -1316,3 +1319,20 @@ services:
         class: eLife\ApiClient\Log\HttpMessageProcessor
         tags:
             - { name: monolog.processor, method: __invoke }
+
+    # Public aliases for private services
+
+    elife.assets.packages:
+        alias: 'assets.packages'
+
+    elife.csa_guzzle.client.elife_api:
+        alias: 'csa_guzzle.client.elife_api'
+
+    elife.logger:
+        alias: 'logger'
+
+    elife.slugify:
+        alias: 'slugify'
+
+    elife.uri_signer:
+        alias: 'uri_signer'

--- a/app/config/services_ci.yml
+++ b/app/config/services_ci.yml
@@ -1,5 +1,8 @@
 services:
 
+    _defaults:
+        public: true
+
     elife.api_validator.validator:
         class: eLife\ApiValidator\MessageValidator\JsonMessageValidator
         arguments:

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -85,7 +85,7 @@ abstract class Controller implements ContainerAwareInterface
     {
         return function ($object) use ($request, $toSlugify) {
             $slug = $request->attributes->get('_route_params')['slug'];
-            $correctSlug = $this->get('slugify')->slugify($toSlugify($object));
+            $correctSlug = $this->get('elife.slugify')->slugify($toSlugify($object));
 
             if ($slug !== $correctSlug) {
                 $route = $request->attributes->get('_route');
@@ -125,7 +125,7 @@ abstract class Controller implements ContainerAwareInterface
             $e = exception_for($reason);
 
             if (false === $e instanceof HttpException) {
-                $this->get('logger')->error($message ?? $e->getMessage(), ['exception' => $e]);
+                $this->get('elife.logger')->error($message ?? $e->getMessage(), ['exception' => $e]);
             }
 
             return $default;
@@ -215,7 +215,7 @@ abstract class Controller implements ContainerAwareInterface
             $profile = $this->get('elife.api_sdk.profiles')->get($user->getUsername())
                 ->otherwise(function ($reason) use ($user) {
                     $e = exception_for($reason);
-                    $this->get('logger')->error("Logging user {$user->getUsername()} out due to {$e->getMessage()}", ['exception' => $e]);
+                    $this->get('elife.logger')->error("Logging user {$user->getUsername()} out due to {$e->getMessage()}", ['exception' => $e]);
 
                     throw new EarlyResponse(new RedirectResponse($this->get('router')->generate('log-out', [], UrlGeneratorInterface::ABSOLUTE_URL)));
                 });

--- a/src/Controller/StatusController.php
+++ b/src/Controller/StatusController.php
@@ -22,7 +22,7 @@ final class StatusController extends Controller
     public function statusAction() : Response
     {
         $requests = array_map(function (string $uri) {
-            return $this->get('csa_guzzle.client.elife_api')->requestAsync('GET', $uri, ['headers' => ['Cache-Control' => 'no-cache, no-store']]);
+            return $this->get('elife.csa_guzzle.client.elife_api')->requestAsync('GET', $uri, ['headers' => ['Cache-Control' => 'no-cache, no-store']]);
         }, $this->getParameter('status_checks'));
 
         try {
@@ -45,7 +45,7 @@ final class StatusController extends Controller
                 })
                 ->otherwise(function ($reason) use ($name) {
                     $exception = exception_for($reason);
-                    $this->get('logger')->critical("$name status check failed", compact('exception'));
+                    $this->get('elife.logger')->critical("$name status check failed", compact('exception'));
 
                     return [
                         'name' => $name,

--- a/src/Controller/WhoWeWorkWithController.php
+++ b/src/Controller/WhoWeWorkWithController.php
@@ -266,9 +266,11 @@ final class WhoWeWorkWithController extends Controller
 
     private function toImageLinks(array $items) : array
     {
-        return array_map(function (array $item) : ImageLink {
+        $packages = $this->get('elife.assets.packages');
+
+        return array_map(function (array $item) use ($packages) : ImageLink {
             $builder = $this->get('elife.journal.view_model.factory.picture_builder')
-                ->create(function (string $type, int $width, int $height = null, float $scale) use ($item) {
+                ->create(function (string $type, int $width, int $height = null, float $scale) use ($item, $packages) {
                     $extension = MediaTypes::toExtension($type);
 
                     $path = "assets/images/logos/{$item['filename']}";
@@ -277,7 +279,7 @@ final class WhoWeWorkWithController extends Controller
                         $path .= "@{$scale}x";
                     }
 
-                    return $this->get('assets.packages')->getUrl("{$path}.{$extension}");
+                    return $packages->getUrl("{$path}.{$extension}");
                 }, $item['type'], 180, null, $item['name']);
 
             return new ImageLink(

--- a/test/Controller/CommunityControllerTest.php
+++ b/test/Controller/CommunityControllerTest.php
@@ -178,7 +178,7 @@ final class CommunityControllerTest extends PageTestCase
         $this->assertSame('The eLife community is working to help address some of the pressures on early-career scientists in a number of ways. Learn more about our work and advisory group, sign up for our monthly news, follow us on Twitter, and explore recent activities below.', $crawler->filter('meta[property="og:description"]')->attr('content'));
         $this->assertSame('The eLife community is working to help address some of the pressures on early-career scientists in a number of ways. Learn more about our work and advisory group, sign up for our monthly news, follow us on Twitter, and explore recent activities below.', $crawler->filter('meta[name="description"]')->attr('content'));
         $this->assertSame('summary_large_image', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
-        $this->assertSame('http://localhost/'.ltrim(self::$kernel->getContainer()->get('assets.packages')->getUrl('assets/images/banners/community-1114x336@1.jpg'), '/'), $crawler->filter('meta[property="og:image"]')->attr('content'));
+        $this->assertSame('http://localhost/'.ltrim(self::$kernel->getContainer()->get('elife.assets.packages')->getUrl('assets/images/banners/community-1114x336@1.jpg'), '/'), $crawler->filter('meta[property="og:image"]')->attr('content'));
         $this->assertSame('1114', $crawler->filter('meta[property="og:image:width"]')->attr('content'));
         $this->assertSame('336', $crawler->filter('meta[property="og:image:height"]')->attr('content'));
         $this->assertEmpty($crawler->filter('meta[name="dc.identifier"]'));

--- a/test/Controller/DownloadControllerTest.php
+++ b/test/Controller/DownloadControllerTest.php
@@ -55,7 +55,7 @@ final class DownloadControllerTest extends WebTestCase
     {
         $uri = 'http://localhost/download/'.base64_encode($fileUri)."/$name";
 
-        return self::$kernel->getContainer()->get('uri_signer')->sign($uri);
+        return self::$kernel->getContainer()->get('elife.uri_signer')->sign($uri);
     }
 
     private function captureContent(callable $callback) : string

--- a/test/Controller/LabsControllerTest.php
+++ b/test/Controller/LabsControllerTest.php
@@ -40,7 +40,7 @@ final class LabsControllerTest extends PageTestCase
         $this->assertSame('Exploring open-source solutions at the intersection of research and technology. Learn more about innovation at eLife, follow us on Twitter, or sign up for our technology and innovation newsletter.', $crawler->filter('meta[property="og:description"]')->attr('content'));
         $this->assertSame('Exploring open-source solutions at the intersection of research and technology. Learn more about innovation at eLife, follow us on Twitter, or sign up for our technology and innovation newsletter.', $crawler->filter('meta[name="description"]')->attr('content'));
         $this->assertSame('summary_large_image', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
-        $this->assertSame('http://localhost/'.ltrim(self::$kernel->getContainer()->get('assets.packages')->getUrl('assets/images/banners/labs-1114x336@1.jpg'), '/'), $crawler->filter('meta[property="og:image"]')->attr('content'));
+        $this->assertSame('http://localhost/'.ltrim(self::$kernel->getContainer()->get('elife.assets.packages')->getUrl('assets/images/banners/labs-1114x336@1.jpg'), '/'), $crawler->filter('meta[property="og:image"]')->attr('content'));
         $this->assertSame('1114', $crawler->filter('meta[property="og:image:width"]')->attr('content'));
         $this->assertSame('336', $crawler->filter('meta[property="og:image:height"]')->attr('content'));
         $this->assertEmpty($crawler->filter('meta[name="dc.identifier"]'));

--- a/test/Controller/MagazineControllerTest.php
+++ b/test/Controller/MagazineControllerTest.php
@@ -82,7 +82,7 @@ final class MagazineControllerTest extends PageTestCase
         $this->assertSame('Highlighting the latest research and giving a voice to scientists', $crawler->filter('meta[property="og:description"]')->attr('content'));
         $this->assertSame('Highlighting the latest research and giving a voice to scientists', $crawler->filter('meta[name="description"]')->attr('content'));
         $this->assertSame('summary_large_image', $crawler->filter('meta[name="twitter:card"]')->attr('content'));
-        $this->assertSame('http://localhost/'.ltrim(self::$kernel->getContainer()->get('assets.packages')->getUrl('assets/images/banners/magazine-1114x336@1.jpg'), '/'), $crawler->filter('meta[property="og:image"]')->attr('content'));
+        $this->assertSame('http://localhost/'.ltrim(self::$kernel->getContainer()->get('elife.assets.packages')->getUrl('assets/images/banners/magazine-1114x336@1.jpg'), '/'), $crawler->filter('meta[property="og:image"]')->attr('content'));
         $this->assertSame('1114', $crawler->filter('meta[property="og:image:width"]')->attr('content'));
         $this->assertSame('336', $crawler->filter('meta[property="og:image:height"]')->attr('content'));
         $this->assertEmpty($crawler->filter('meta[name="dc.identifier"]'));

--- a/test/Helper/DownloadLinkUriGeneratorTest.php
+++ b/test/Helper/DownloadLinkUriGeneratorTest.php
@@ -28,7 +28,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
 
         $container = static::$kernel->getContainer();
         $this->downloadLinkUriGenerator = $container->get('elife.journal.helper.download_link_uri_generator');
-        $this->uriSigner = $container->get('uri_signer');
+        $this->uriSigner = $container->get('elife.uri_signer');
         $this->defaultBaseUrl =
             $container->getParameter('router.request_context.scheme')
             .'://'


### PR DESCRIPTION
Symfony emits deprecation notices, this prevents most of them (think there's only 2 left, which aren't easy to fix).