### PR TITLE
Fix redirect after logging in on /submit

### DIFF
--- a/test/Controller/AuthenticationTest.php
+++ b/test/Controller/AuthenticationTest.php
@@ -357,28 +357,4 @@ final class AuthenticationTest extends WebTestCase
             )
         );
     }
-
-    private function readyToken()
-    {
-        $this->mockApiResponse(
-            new Request(
-                'POST',
-                'http://api.elifesciences.org/oauth2/token',
-                ['Content-Type' => 'application/x-www-form-urlencoded'],
-                build_query(['code' => 'foo', 'grant_type' => 'authorization_code', 'client_id' => 'journal--local-id', 'client_secret' => 'journal--local-secret', 'redirect_uri' => 'http://localhost/log-in/check'])
-            ),
-            new Response(
-                200,
-                ['Content-Type' => 'application/json'],
-                json_encode([
-                    'access_token' => 'token',
-                    'expires_in' => 3920,
-                    'token_type' => 'Bearer',
-                    'id' => 'jcarberry',
-                    'orcid' => '0000-0002-1825-0097',
-                    'name' => 'Josiah Carberry',
-                ])
-            )
-        );
-    }
 }

--- a/test/WebTestCase.php
+++ b/test/WebTestCase.php
@@ -9,6 +9,8 @@ use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
+use function GuzzleHttp\json_encode;
+use function GuzzleHttp\Psr7\build_query;
 
 abstract class WebTestCase extends BaseWebTestCase
 {
@@ -43,6 +45,30 @@ abstract class WebTestCase extends BaseWebTestCase
                         'index' => 'Carberry, Josiah',
                     ],
                     'orcid' => '0000-0002-1825-0097',
+                ])
+            )
+        );
+    }
+
+    final protected function readyToken()
+    {
+        $this->mockApiResponse(
+            new Request(
+                'POST',
+                'http://api.elifesciences.org/oauth2/token',
+                ['Content-Type' => 'application/x-www-form-urlencoded'],
+                build_query(['code' => 'foo', 'grant_type' => 'authorization_code', 'client_id' => 'journal--local-id', 'client_secret' => 'journal--local-secret', 'redirect_uri' => 'http://localhost/log-in/check'])
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'access_token' => 'token',
+                    'expires_in' => 3920,
+                    'token_type' => 'Bearer',
+                    'id' => 'jcarberry',
+                    'orcid' => '0000-0002-1825-0097',
+                    'name' => 'Josiah Carberry',
                 ])
             )
         );


### PR DESCRIPTION
When xPub is enabled and clicking the 'Submit my research' header and not logged in, the `/submit` route causes you to log in. However, the `Refer` header is the original page you were on, rather than `/submit`, so you're sent back to that page rather than xPub. It works fine when logged in.

This changes the behaviour on `/submit` to do an internal sub-request, rather than a redirect, which allows us to change the `Referer` header. It also removes a hop.