### PR TITLE
Add new-session property in the xPub JWT

### DIFF
--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -25,11 +25,12 @@ final class SubmitController extends Controller
             ];
             $subRequest = $request->duplicate(null, null, $path);
             $subRequest->headers->set('Referer', $request->getUri());
+            $subRequest->getSession()->set('journal.submit', true);
 
             return $this->get('kernel')->handle($subRequest, KernelInterface::SUB_REQUEST);
         }
 
-        $jwt = $this->get('elife.journal.security.xpub.token_generator')->generate($user);
+        $jwt = $this->get('elife.journal.security.xpub.token_generator')->generate($user, $request->getSession()->remove('journal.submit') ?? false);
 
         return new RedirectResponse("{$this->getParameter('submit_url')}#{$jwt}");
     }

--- a/src/Security/XpubTokenGenerator.php
+++ b/src/Security/XpubTokenGenerator.php
@@ -18,13 +18,14 @@ final class XpubTokenGenerator
         $this->clientSecret = $clientSecret;
     }
 
-    public function generate(UserInterface $user) : string
+    public function generate(UserInterface $user, bool $newSession = false) : string
     {
         return JWT::encode([
             'iss' => $this->clientId,
             'iat' => time(),
             'exp' => time() + self::TOKEN_TTL,
             'id' => $user->getUsername(),
+            'new-session' => $newSession,
         ], $this->clientSecret);
     }
 }

--- a/src/ViewModel/Factory/SiteHeaderFactory.php
+++ b/src/ViewModel/Factory/SiteHeaderFactory.php
@@ -119,7 +119,7 @@ final class SiteHeaderFactory
             $searchItem,
         ]);
 
-        if ($this->authorizationChecker->isGranted('FEATURE_XPUB')) {
+        if ($this->authorizationChecker->isGranted('FEATURE_XPUB') && $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') ) {
             $submitUrl = $this->urlGenerator->generate('submit');
         }
 

--- a/src/ViewModel/Factory/SiteHeaderFactory.php
+++ b/src/ViewModel/Factory/SiteHeaderFactory.php
@@ -119,7 +119,7 @@ final class SiteHeaderFactory
             $searchItem,
         ]);
 
-        if ($this->authorizationChecker->isGranted('FEATURE_XPUB') && $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') ) {
+        if ($this->authorizationChecker->isGranted('FEATURE_XPUB') && $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             $submitUrl = $this->urlGenerator->generate('submit');
         }
 

--- a/test/Controller/SubmitControllerTest.php
+++ b/test/Controller/SubmitControllerTest.php
@@ -66,7 +66,9 @@ final class SubmitControllerTest extends WebTestCase
 
         $this->assertSameUri('http://submit.elifesciences.org/path', $location->withFragment(''));
 
-        JWT::decode($location->getFragment(), $this->getParameter('xpub_client_secret'), ['HS256']);
+        $jwt = (array) JWT::decode($location->getFragment(), $this->getParameter('xpub_client_secret'), ['HS256']);
+
+        $this->assertTrue($jwt['new-session']);
     }
 
     /**
@@ -85,7 +87,9 @@ final class SubmitControllerTest extends WebTestCase
 
         $this->assertSameUri('http://submit.elifesciences.org/path', $location->withFragment(''));
 
-        JWT::decode($location->getFragment(), $this->getParameter('xpub_client_secret'), ['HS256']);
+        $jwt = (array) JWT::decode($location->getFragment(), $this->getParameter('xpub_client_secret'), ['HS256']);
+
+        $this->assertFalse($jwt['new-session']);
     }
 
     protected static function createClient(array $options = [], array $server = [])

--- a/test/Security/XpubTokenGeneratorTest.php
+++ b/test/Security/XpubTokenGeneratorTest.php
@@ -22,14 +22,15 @@ final class XpubTokenGeneratorTest extends TestCase
 
         $tokenGenerator = new XpubTokenGenerator('client_id', 'client_secret');
 
-        $token = $tokenGenerator->generate(new User('username', 'password'));
+        $token = $tokenGenerator->generate(new User('username', 'password'), true);
 
         $generated = (array) JWT::decode($token, 'client_secret', ['HS256']);
 
-        $this->assertCount(4, $generated);
+        $this->assertCount(5, $generated);
         $this->assertSame('client_id', $generated['iss']);
         $this->assertSame($now, $generated['iat']);
         $this->assertSame($now + 60, $generated['exp']);
         $this->assertSame('username', $generated['id']);
+        $this->assertTrue($generated['new-session']);
     }
 }

--- a/test/ViewModel/Factory/SiteHeaderFactoryTest.php
+++ b/test/ViewModel/Factory/SiteHeaderFactoryTest.php
@@ -4,7 +4,9 @@ namespace test\eLife\Journal\ViewModel\Factory;
 
 use eLife\Journal\ViewModel\Factory\SiteHeaderFactory;
 use eLife\Patterns\ViewModel\SiteHeader;
+use KnpU\OAuth2ClientBundle\Security\User\OAuthUser;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 use test\eLife\Journal\KernelTestCase;
 
 final class SiteHeaderFactoryTest extends KernelTestCase
@@ -46,13 +48,30 @@ final class SiteHeaderFactoryTest extends KernelTestCase
      * @test
      * @backupGlobals enabled
      */
-    public function it_links_to_the_submit_route_when_the_feature_flag_is_enable()
+    public function it_links_directly_to_the_submit_site_when_the_feature_flag_is_enable_and_you_are_not_logged_in()
     {
         $_ENV['FEATURE_XPUB'] = true;
 
         // Required to enable the authorization checker
         $tokenStorage = static::$kernel->getContainer()->get('security.token_storage');
         $tokenStorage->setToken(new AnonymousToken('secret', 'anon.'));
+
+        $siteHeader = $this->siteHeaderFactory->createSiteHeader();
+
+        $this->assertSame('http://submit.elifesciences.org/path', $siteHeader['secondaryLinks']['linkedItems'][2]['button']['path']);
+    }
+
+    /**
+     * @test
+     * @backupGlobals enabled
+     */
+    public function it_links_to_the_submit_route_when_the_feature_flag_is_enable_and_you_are_logged_in()
+    {
+        $_ENV['FEATURE_XPUB'] = true;
+
+        // Required to enable the authorization checker
+        $tokenStorage = static::$kernel->getContainer()->get('security.token_storage');
+        $tokenStorage->setToken(new PostAuthenticationGuardToken(new OAuthUser('jcarberry', $roles = ['ROLE_USER', 'ROLE_OAUTH_USER']), 'main', $roles));
 
         $siteHeader = $this->siteHeaderFactory->createSiteHeader();
 

--- a/test/ViewModel/Factory/SiteHeaderFactoryTest.php
+++ b/test/ViewModel/Factory/SiteHeaderFactoryTest.php
@@ -37,9 +37,23 @@ final class SiteHeaderFactoryTest extends KernelTestCase
     /**
      * @test
      */
-    public function it_links_directly_to_the_submit_site_when_the_feature_flag_is_disabled()
+    public function it_links_directly_to_the_submit_site_when_the_feature_flag_is_disabled_and_you_are_not_logged_in()
     {
         $siteHeader = $this->siteHeaderFactory->createSiteHeader();
+
+        $this->assertSame('http://submit.elifesciences.org/path', $siteHeader['secondaryLinks']['linkedItems'][2]['button']['path']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_links_directly_to_the_submit_site_when_the_feature_flag_is_disabled_and_you_are_logged_in()
+    {
+        $siteHeader = $this->siteHeaderFactory->createSiteHeader();
+
+        // Required to enable the authorization checker
+        $tokenStorage = static::$kernel->getContainer()->get('security.token_storage');
+        $tokenStorage->setToken(new PostAuthenticationGuardToken(new OAuthUser('jcarberry', $roles = ['ROLE_USER', 'ROLE_OAUTH_USER']), 'main', $roles));
 
         $this->assertSame('http://submit.elifesciences.org/path', $siteHeader['secondaryLinks']['linkedItems'][2]['button']['path']);
     }


### PR DESCRIPTION
Changes the site header 'Submit my research' link to always be the `submit_url` setting, unless you're logged in (when it's `/submit`). The JWT passed to Xpub with then contain a new property (currently called `new-session`) indicating whether the new session was caused by being visiting `/submit` or not.