### PR TITLE
Use docker-compose down -v

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Reproduce a ci failure
 ----------------------
 
 ```
-docker-compose down -v
+docker-compose -f docker-compose.yml -f docker-compose.ci.yml down -v
 SELENIUM_IMAGE_SUFFIX=-debug docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --build
 docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci .ci/behat
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation
 Running the site locally
 ------------------------
 
-1. `docker-compose up --build -V`
+1. `docker-compose down -v && docker-compose up --build`
 2. Open `http://localhost:8080` in your browser.
 
 Regenerating critical CSS
@@ -60,6 +60,7 @@ Reproduce a ci failure
 ----------------------
 
 ```
-SELENIUM_IMAGE_SUFFIX=-debug docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --build -V
+docker-compose down -v
+SELENIUM_IMAGE_SUFFIX=-debug docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --build
 docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci .ci/behat
 ```


### PR DESCRIPTION
We observed `docker-compose up --build -V` not deleting the `vendor` volume; looking at the man page it may be right as it says `anonymous volumes`.

I suspect that given ours are named in `volumes:` [they are not considered anonymous](https://docs.docker.com/storage/volumes/#remove-volumes) even without a specified host folder:

```
Named volumes have a specific source form outside the container, for example awesome:/bar.

Anonymous volumes have no specific source so when the container is deleted, instruct the Docker Engine daemon to remove them.
```

So most of ours are named, not anonymous; suggesting to default to `docker-compose down -v` to clean them up.