### PR TITLE
Add link to reproducible document from article 30274

### DIFF
--- a/.docker/parameters.yml
+++ b/.docker/parameters.yml
@@ -30,6 +30,6 @@ parameters:
     xpub_client_secret: ThisIsASecret
     subject_rewrites: []
     rds_articles:
-        30274: https://repro.elifesciences.org/example.html
+        16846: https://repro.elifesciences.org/example.html
     cache_control: private, no-cache, no-store, must-revalidate
     feature_xpub: true

--- a/.docker/parameters.yml
+++ b/.docker/parameters.yml
@@ -30,6 +30,6 @@ parameters:
     xpub_client_secret: ThisIsASecret
     subject_rewrites: []
     rds_articles:
-        16846: https://repro.elifesciences.org/example.html
+        '16846': https://repro.elifesciences.org/example.html
     cache_control: private, no-cache, no-store, must-revalidate
     feature_xpub: true

--- a/.docker/parameters.yml
+++ b/.docker/parameters.yml
@@ -29,5 +29,7 @@ parameters:
     xpub_client_id: some-id
     xpub_client_secret: ThisIsASecret
     subject_rewrites: []
+    rds_articles:
+        30274: https://repro.elifesciences.org/example.html
     cache_control: private, no-cache, no-store, must-revalidate
     feature_xpub: true

--- a/app/config/config_ci.yml
+++ b/app/config/config_ci.yml
@@ -20,6 +20,8 @@ parameters:
       - from_id: old-subject
         to_id: new-subject
         to_name: New Subject
+    rds_articles:
+      12345: https://repro.elifesciences.org/example.html
     submit_url: http://submit.elifesciences.org/path
 
 framework:

--- a/app/config/config_ci.yml
+++ b/app/config/config_ci.yml
@@ -21,7 +21,7 @@ parameters:
         to_id: new-subject
         to_name: New Subject
     rds_articles:
-      12345: https://repro.elifesciences.org/example.html
+        12345: https://repro.elifesciences.org/example.html
     submit_url: http://submit.elifesciences.org/path
 
 framework:

--- a/app/config/config_ci.yml
+++ b/app/config/config_ci.yml
@@ -21,7 +21,7 @@ parameters:
         to_id: new-subject
         to_name: New Subject
     rds_articles:
-        12345: https://repro.elifesciences.org/example.html
+        '12345': https://repro.elifesciences.org/example.html
     submit_url: http://submit.elifesciences.org/path
 
 framework:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -33,5 +33,7 @@ parameters:
       - from_id: from-subject
         to_id: to-subject
         to_name: To Subject Name
+    rds_articles:
+        30274: https://repro.elifesciences.org/example.html
     cache_control: public, max-age=300, stale-while-revalidate=300, stale-if-error=86400
     feature_xpub: true

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -34,6 +34,6 @@ parameters:
         to_id: to-subject
         to_name: To Subject Name
     rds_articles:
-        30274: https://repro.elifesciences.org/example.html
+        '30274': https://repro.elifesciences.org/example.html
     cache_control: public, max-age=300, stale-while-revalidate=300, stale-if-error=86400
     feature_xpub: true

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -822,6 +822,10 @@ final class ArticlesController extends Controller
                     }
                 }
 
+                if ($item->getId() == '30274') {
+                  $infoBars[] = new InfoBar('This research is available in a <a href="https://repro.elifesciences.org/example.html">reproducible view</a>.', InfoBar::TYPE_WARNING);
+                }
+
                 return $infoBars;
             });
 

--- a/src/Controller/ArticlesController.php
+++ b/src/Controller/ArticlesController.php
@@ -822,8 +822,10 @@ final class ArticlesController extends Controller
                     }
                 }
 
-                if ($item->getId() == '30274') {
-                  $infoBars[] = new InfoBar('This research is available in a <a href="https://repro.elifesciences.org/example.html">reproducible view</a>.', InfoBar::TYPE_WARNING);
+                $rdsArticles = $this->getParameter('rds_articles');
+
+                if (isset($rdsArticles[$item->getId()])) {
+                    $infoBars[] = new InfoBar('This research is available in a <a href="'.$rdsArticles[$item->getId()].'">reproducible view</a>.', InfoBar::TYPE_WARNING);
                 }
 
                 return $infoBars;

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1137,234 +1137,239 @@ final class ArticleControllerTest extends PageTestCase
         $this->assertSame('Categories and tags', $crawler->filter('.grid-column > section:nth-of-type(3) .article-meta__group_title')->text());
     }
 
-  /**
-   * @test
-   */
-  public function it_displays_rds_info_bar_when_it_has_associated_rds()
-  {
-    $client = static::createClient();
+    /**
+     * @test
+     */
+    public function it_displays_rds_info_bar_when_it_has_associated_rds()
+    {
+        $client = static::createClient();
 
-    $this->mockApiResponse(
-      new Request(
-        'GET',
-        'http://api.elifesciences.org/articles/12345',
-        ['Accept' => 'application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2']
-      ),
-      new Response(
-        200,
-        ['Content-Type' => 'application/vnd.elife.article-poa+json; version=2'],
-        json_encode([
-          'status' => 'poa',
-          'stage' => 'published',
-          'id' => '12345',
-          'version' => 1,
-          'type' => 'research-article',
-          'doi' => '10.7554/eLife.12345',
-          'title' => 'Article title',
-          'published' => '2010-01-01T00:00:00Z',
-          'versionDate' => '2010-01-01T00:00:00Z',
-          'statusDate' => '2010-01-01T00:00:00Z',
-          'volume' => 1,
-          'elocationId' => 'e12345',
-          'copyright' => [
-            'license' => 'CC-BY-4.0',
-            'holder' => 'Author One',
-            'statement' => 'Copyright statement.',
-          ],
-          'authorLine' => 'Author One et al.',
-          'authors' => [
-            [
-              'type' => 'person',
-              'name' => [
-                'preferred' => 'Author One',
-                'index' => 'Author One',
-              ],
-            ],
-          ],
-          'reviewers' => [
-            [
-              'name' => [
-                'preferred' => 'Reviewer 1',
-                'index' => 'Reviewer 1',
-              ],
-              'role' => 'Reviewer',
-              'affiliations' => [
-                [
-                  'name' => ['Institution'],
-                  'address' => [
-                    'formatted' => ['Country'],
-                    'components' => [
-                      'country' => 'Country',
+        $this->mockApiResponse(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles/12345',
+                ['Accept' => 'application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2']
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/vnd.elife.article-poa+json; version=2'],
+                json_encode([
+                    'status' => 'poa',
+                    'stage' => 'published',
+                    'id' => '12345',
+                    'version' => 1,
+                    'type' => 'research-article',
+                    'doi' => '10.7554/eLife.12345',
+                    'title' => 'Article title',
+                    'published' => '2010-01-01T00:00:00Z',
+                    'versionDate' => '2010-01-01T00:00:00Z',
+                    'statusDate' => '2010-01-01T00:00:00Z',
+                    'volume' => 1,
+                    'elocationId' => 'e12345',
+                    'copyright' => [
+                        'license' => 'CC-BY-4.0',
+                        'holder' => 'Author One',
+                        'statement' => 'Copyright statement.',
                     ],
-                  ],
-                ],
-              ],
-            ],
-          ],
-        ])
-      )
-    );
-
-    $this->mockApiResponse(
-      new Request(
-        'GET',
-        'http://api.elifesciences.org/articles/12345/versions',
-        [
-          'Accept' => [
-            'application/vnd.elife.article-history+json; version=1',
-          ],
-        ]
-      ),
-      new Response(
-        200,
-        ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
-        json_encode([
-          'versions' => [
-            [
-              'status' => 'poa',
-              'stage' => 'published',
-              'id' => '12345',
-              'version' => 1,
-              'type' => 'research-article',
-              'doi' => '10.7554/eLife.12345',
-              'title' => 'Article title',
-              'published' => '2010-01-01T00:00:00Z',
-              'versionDate' => '2010-01-01T00:00:00Z',
-              'statusDate' => '2010-01-01T00:00:00Z',
-              'volume' => 1,
-              'elocationId' => 'e12345',
-              'copyright' => [
-                'license' => 'CC-BY-4.0',
-                'holder' => 'Author One',
-                'statement' => 'Copyright statement.',
-              ],
-              'authorLine' => 'Author One et al.',
-            ],
-          ],
-        ])
-      )
-    );
-
-    $crawler = $client->request('GET', '/articles/12345');
-
-    $this->assertSame(200, $client->getResponse()->getStatusCode());
-    $this->assertContains('This research is available in a reproducible view.',
-      array_map('trim', $crawler->filter('.info-bar--warning')->extract(['_text'])));
-  }
-  /**
-   * @test
-   */
-  public function it_does_not_display_rds_info_bar_when_it_has_no_associated_rds()
-  {
-    $client = static::createClient();
-
-    $this->mockApiResponse(
-      new Request(
-        'GET',
-        'http://api.elifesciences.org/articles/00001',
-        ['Accept' => 'application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2']
-      ),
-      new Response(
-        200,
-        ['Content-Type' => 'application/vnd.elife.article-poa+json; version=2'],
-        json_encode([
-          'status' => 'poa',
-          'stage' => 'published',
-          'id' => '00001',
-          'version' => 1,
-          'type' => 'research-article',
-          'doi' => '10.7554/eLife.00001',
-          'title' => 'Article title',
-          'published' => '2010-01-01T00:00:00Z',
-          'versionDate' => '2010-01-01T00:00:00Z',
-          'statusDate' => '2010-01-01T00:00:00Z',
-          'volume' => 1,
-          'elocationId' => 'e00001',
-          'copyright' => [
-            'license' => 'CC-BY-4.0',
-            'holder' => 'Author One',
-            'statement' => 'Copyright statement.',
-          ],
-          'authorLine' => 'Author One et al.',
-          'authors' => [
-            [
-              'type' => 'person',
-              'name' => [
-                'preferred' => 'Author One',
-                'index' => 'Author One',
-              ],
-            ],
-          ],
-          'reviewers' => [
-            [
-              'name' => [
-                'preferred' => 'Reviewer 1',
-                'index' => 'Reviewer 1',
-              ],
-              'role' => 'Reviewer',
-              'affiliations' => [
-                [
-                  'name' => ['Institution'],
-                  'address' => [
-                    'formatted' => ['Country'],
-                    'components' => [
-                      'country' => 'Country',
+                    'authorLine' => 'Author One et al.',
+                    'authors' => [
+                        [
+                            'type' => 'person',
+                            'name' => [
+                                'preferred' => 'Author One',
+                                'index' => 'Author One',
+                            ],
+                        ],
                     ],
-                  ],
-                ],
-              ],
-            ],
-          ],
-        ])
-      )
-    );
+                    'reviewers' => [
+                        [
+                            'name' => [
+                                'preferred' => 'Reviewer 1',
+                                'index' => 'Reviewer 1',
+                            ],
+                            'role' => 'Reviewer',
+                            'affiliations' => [
+                                [
+                                    'name' => ['Institution'],
+                                    'address' => [
+                                        'formatted' => ['Country'],
+                                        'components' => [
+                                            'country' => 'Country',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ])
+            )
+        );
 
-    $this->mockApiResponse(
-      new Request(
-        'GET',
-        'http://api.elifesciences.org/articles/00001/versions',
-        [
-          'Accept' => [
-            'application/vnd.elife.article-history+json; version=1',
-          ],
-        ]
-      ),
-      new Response(
-        200,
-        ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
-        json_encode([
-          'versions' => [
-            [
-              'status' => 'poa',
-              'stage' => 'published',
-              'id' => '00001',
-              'version' => 1,
-              'type' => 'research-article',
-              'doi' => '10.7554/eLife.00001',
-              'title' => 'Article title',
-              'published' => '2010-01-01T00:00:00Z',
-              'versionDate' => '2010-01-01T00:00:00Z',
-              'statusDate' => '2010-01-01T00:00:00Z',
-              'volume' => 1,
-              'elocationId' => 'e00001',
-              'copyright' => [
-                'license' => 'CC-BY-4.0',
-                'holder' => 'Author One',
-                'statement' => 'Copyright statement.',
-              ],
-              'authorLine' => 'Author One et al.',
-            ],
-          ],
-        ])
-      )
-    );
+        $this->mockApiResponse(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles/12345/versions',
+                [
+                    'Accept' => [
+                        'application/vnd.elife.article-history+json; version=1',
+                    ],
+                ]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+                json_encode([
+                    'versions' => [
+                        [
+                            'status' => 'poa',
+                            'stage' => 'published',
+                            'id' => '12345',
+                            'version' => 1,
+                            'type' => 'research-article',
+                            'doi' => '10.7554/eLife.12345',
+                            'title' => 'Article title',
+                            'published' => '2010-01-01T00:00:00Z',
+                            'versionDate' => '2010-01-01T00:00:00Z',
+                            'statusDate' => '2010-01-01T00:00:00Z',
+                            'volume' => 1,
+                            'elocationId' => 'e12345',
+                            'copyright' => [
+                                'license' => 'CC-BY-4.0',
+                                'holder' => 'Author One',
+                                'statement' => 'Copyright statement.',
+                            ],
+                            'authorLine' => 'Author One et al.',
+                        ],
+                    ],
+                ])
+            )
+        );
 
-    $crawler = $client->request('GET', '/articles/00001');
+        $crawler = $client->request('GET', '/articles/12345');
 
-    $this->assertSame(200, $client->getResponse()->getStatusCode());
-    $this->assertNotContains('reproducible view',
-      array_map('trim', $crawler->filter('.info-bar')->eq(0)->extract(['_text'])));
-  }
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertContains(
+            'This research is available in a reproducible view.',
+            array_map('trim', $crawler->filter('.info-bar--warning')->extract(['_text']))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_display_rds_info_bar_when_it_has_no_associated_rds()
+    {
+        $client = static::createClient();
+
+        $this->mockApiResponse(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles/00001',
+                ['Accept' => 'application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2']
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/vnd.elife.article-poa+json; version=2'],
+                json_encode([
+                    'status' => 'poa',
+                    'stage' => 'published',
+                    'id' => '00001',
+                    'version' => 1,
+                    'type' => 'research-article',
+                    'doi' => '10.7554/eLife.00001',
+                    'title' => 'Article title',
+                    'published' => '2010-01-01T00:00:00Z',
+                    'versionDate' => '2010-01-01T00:00:00Z',
+                    'statusDate' => '2010-01-01T00:00:00Z',
+                    'volume' => 1,
+                    'elocationId' => 'e00001',
+                    'copyright' => [
+                        'license' => 'CC-BY-4.0',
+                        'holder' => 'Author One',
+                        'statement' => 'Copyright statement.',
+                    ],
+                    'authorLine' => 'Author One et al.',
+                    'authors' => [
+                        [
+                            'type' => 'person',
+                            'name' => [
+                                'preferred' => 'Author One',
+                                'index' => 'Author One',
+                            ],
+                        ],
+                    ],
+                    'reviewers' => [
+                        [
+                            'name' => [
+                                'preferred' => 'Reviewer 1',
+                                'index' => 'Reviewer 1',
+                            ],
+                            'role' => 'Reviewer',
+                            'affiliations' => [
+                                [
+                                    'name' => ['Institution'],
+                                    'address' => [
+                                        'formatted' => ['Country'],
+                                        'components' => [
+                                            'country' => 'Country',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ])
+            )
+        );
+
+        $this->mockApiResponse(
+            new Request(
+                'GET',
+                'http://api.elifesciences.org/articles/00001/versions',
+                [
+                    'Accept' => [
+                        'application/vnd.elife.article-history+json; version=1',
+                    ],
+                ]
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+                json_encode([
+                    'versions' => [
+                        [
+                            'status' => 'poa',
+                            'stage' => 'published',
+                            'id' => '00001',
+                            'version' => 1,
+                            'type' => 'research-article',
+                            'doi' => '10.7554/eLife.00001',
+                            'title' => 'Article title',
+                            'published' => '2010-01-01T00:00:00Z',
+                            'versionDate' => '2010-01-01T00:00:00Z',
+                            'statusDate' => '2010-01-01T00:00:00Z',
+                            'volume' => 1,
+                            'elocationId' => 'e00001',
+                            'copyright' => [
+                                'license' => 'CC-BY-4.0',
+                                'holder' => 'Author One',
+                                'statement' => 'Copyright statement.',
+                            ],
+                            'authorLine' => 'Author One et al.',
+                        ],
+                    ],
+                ])
+            )
+        );
+
+        $crawler = $client->request('GET', '/articles/00001');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertNotContains(
+            'reproducible view',
+            array_map('trim', $crawler->filter('.info-bar')->eq(0)->extract(['_text']))
+        );
+    }
     /**
      * @test
      */

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1137,6 +1137,115 @@ final class ArticleControllerTest extends PageTestCase
         $this->assertSame('Categories and tags', $crawler->filter('.grid-column > section:nth-of-type(3) .article-meta__group_title')->text());
     }
 
+  /**
+   * @test
+   */
+    public function it_displays_rds_info_bar_when_it_has_associated_rds()
+    {
+      $client = static::createClient();
+
+      $crawler = $client->request('GET', $this->getPreviousVersionUrl());
+
+      $this->mockApiResponse(
+        new Request(
+          'GET',
+          'http://api.elifesciences.org/articles/12345/',
+          [
+            'Accept' => [
+              'application/vnd.elife.article-history+json; version=1',
+            ],
+          ]
+        ),
+        new Response(
+          200,
+          ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+          json_encode([
+            'versions' => [
+              [
+                'status' => 'poa',
+                'stage' => 'published',
+                'id' => '12345',
+                'version' => 1,
+                'type' => 'research-article',
+                'doi' => '10.7554/eLife.00001',
+                'title' => 'Article title',
+                'published' => '2010-01-01T00:00:00Z',
+                'versionDate' => '2010-01-01T00:00:00Z',
+                'statusDate' => '2010-01-01T00:00:00Z',
+                'volume' => 1,
+                'elocationId' => 'e00001',
+                'copyright' => [
+                  'license' => 'CC-BY-4.0',
+                  'holder' => 'Author One',
+                  'statement' => 'Copyright statement.',
+                ],
+                'authorLine' => 'Author One et al.',
+              ],
+            ],
+          ])
+        )
+      );
+
+      $this->assertSame(200, $client->getResponse()->getStatusCode());
+
+      $this->assertContains('This research is available in a reproducible view.', trim($crawler->filter('.info-bar--warning')->text()));
+
+    }
+
+  /**
+   * @test
+   */
+    public function it_does_not_display_rds_info_bar_when_it_has_no_associated_rds()
+    {
+      $client = static::createClient();
+
+      $crawler = $client->request('GET', $this->getPreviousVersionUrl());
+
+      $this->mockApiResponse(
+        new Request(
+          'GET',
+          'http://api.elifesciences.org/articles/00001/',
+          [
+            'Accept' => [
+              'application/vnd.elife.article-history+json; version=1',
+            ],
+          ]
+        ),
+        new Response(
+          200,
+          ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+          json_encode([
+            'versions' => [
+              [
+                'status' => 'poa',
+                'stage' => 'published',
+                'id' => '00001',
+                'version' => 1,
+                'type' => 'research-article',
+                'doi' => '10.7554/eLife.00001',
+                'title' => 'Article title',
+                'published' => '2010-01-01T00:00:00Z',
+                'versionDate' => '2010-01-01T00:00:00Z',
+                'statusDate' => '2010-01-01T00:00:00Z',
+                'volume' => 1,
+                'elocationId' => 'e00001',
+                'copyright' => [
+                  'license' => 'CC-BY-4.0',
+                  'holder' => 'Author One',
+                  'statement' => 'Copyright statement.',
+                ],
+                'authorLine' => 'Author One et al.',
+              ],
+            ],
+          ])
+        )
+      );
+
+      $this->assertSame(200, $client->getResponse()->getStatusCode());
+      $this->assertNotContains('This research is available in a', array_map('trim', $crawler->filter('.info-bar')->extract(['_text'])));
+
+    }
+
     /**
      * @test
      */

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1140,112 +1140,231 @@ final class ArticleControllerTest extends PageTestCase
   /**
    * @test
    */
-    public function it_displays_rds_info_bar_when_it_has_associated_rds()
-    {
-      $client = static::createClient();
+  public function it_displays_rds_info_bar_when_it_has_associated_rds()
+  {
+    $client = static::createClient();
 
-      $crawler = $client->request('GET', $this->getPreviousVersionUrl());
-
-      $this->mockApiResponse(
-        new Request(
-          'GET',
-          'http://api.elifesciences.org/articles/12345/',
-          [
-            'Accept' => [
-              'application/vnd.elife.article-history+json; version=1',
-            ],
-          ]
-        ),
-        new Response(
-          200,
-          ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
-          json_encode([
-            'versions' => [
-              [
-                'status' => 'poa',
-                'stage' => 'published',
-                'id' => '12345',
-                'version' => 1,
-                'type' => 'research-article',
-                'doi' => '10.7554/eLife.00001',
-                'title' => 'Article title',
-                'published' => '2010-01-01T00:00:00Z',
-                'versionDate' => '2010-01-01T00:00:00Z',
-                'statusDate' => '2010-01-01T00:00:00Z',
-                'volume' => 1,
-                'elocationId' => 'e00001',
-                'copyright' => [
-                  'license' => 'CC-BY-4.0',
-                  'holder' => 'Author One',
-                  'statement' => 'Copyright statement.',
-                ],
-                'authorLine' => 'Author One et al.',
+    $this->mockApiResponse(
+      new Request(
+        'GET',
+        'http://api.elifesciences.org/articles/12345',
+        ['Accept' => 'application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2']
+      ),
+      new Response(
+        200,
+        ['Content-Type' => 'application/vnd.elife.article-poa+json; version=2'],
+        json_encode([
+          'status' => 'poa',
+          'stage' => 'published',
+          'id' => '12345',
+          'version' => 1,
+          'type' => 'research-article',
+          'doi' => '10.7554/eLife.12345',
+          'title' => 'Article title',
+          'published' => '2010-01-01T00:00:00Z',
+          'versionDate' => '2010-01-01T00:00:00Z',
+          'statusDate' => '2010-01-01T00:00:00Z',
+          'volume' => 1,
+          'elocationId' => 'e12345',
+          'copyright' => [
+            'license' => 'CC-BY-4.0',
+            'holder' => 'Author One',
+            'statement' => 'Copyright statement.',
+          ],
+          'authorLine' => 'Author One et al.',
+          'authors' => [
+            [
+              'type' => 'person',
+              'name' => [
+                'preferred' => 'Author One',
+                'index' => 'Author One',
               ],
             ],
-          ])
-        )
-      );
+          ],
+          'reviewers' => [
+            [
+              'name' => [
+                'preferred' => 'Reviewer 1',
+                'index' => 'Reviewer 1',
+              ],
+              'role' => 'Reviewer',
+              'affiliations' => [
+                [
+                  'name' => ['Institution'],
+                  'address' => [
+                    'formatted' => ['Country'],
+                    'components' => [
+                      'country' => 'Country',
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ])
+      )
+    );
 
-      $this->assertSame(200, $client->getResponse()->getStatusCode());
+    $this->mockApiResponse(
+      new Request(
+        'GET',
+        'http://api.elifesciences.org/articles/12345/versions',
+        [
+          'Accept' => [
+            'application/vnd.elife.article-history+json; version=1',
+          ],
+        ]
+      ),
+      new Response(
+        200,
+        ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+        json_encode([
+          'versions' => [
+            [
+              'status' => 'poa',
+              'stage' => 'published',
+              'id' => '12345',
+              'version' => 1,
+              'type' => 'research-article',
+              'doi' => '10.7554/eLife.12345',
+              'title' => 'Article title',
+              'published' => '2010-01-01T00:00:00Z',
+              'versionDate' => '2010-01-01T00:00:00Z',
+              'statusDate' => '2010-01-01T00:00:00Z',
+              'volume' => 1,
+              'elocationId' => 'e12345',
+              'copyright' => [
+                'license' => 'CC-BY-4.0',
+                'holder' => 'Author One',
+                'statement' => 'Copyright statement.',
+              ],
+              'authorLine' => 'Author One et al.',
+            ],
+          ],
+        ])
+      )
+    );
 
-      $this->assertContains('This research is available in a reproducible view.', trim($crawler->filter('.info-bar--warning')->text()));
+    $crawler = $client->request('GET', '/articles/12345');
 
-    }
-
+    $this->assertSame(200, $client->getResponse()->getStatusCode());
+    $this->assertContains('This research is available in a reproducible view',
+      array_map('trim', $crawler->filter('.info-bar--warning')->extract(['_text'])));
+  }
   /**
    * @test
    */
-    public function it_does_not_display_rds_info_bar_when_it_has_no_associated_rds()
-    {
-      $client = static::createClient();
+  public function it_does_not_display_rds_info_bar_when_it_has_no_associated_rds()
+  {
+    $client = static::createClient();
 
-      $crawler = $client->request('GET', $this->getPreviousVersionUrl());
-
-      $this->mockApiResponse(
-        new Request(
-          'GET',
-          'http://api.elifesciences.org/articles/00001/',
-          [
-            'Accept' => [
-              'application/vnd.elife.article-history+json; version=1',
-            ],
-          ]
-        ),
-        new Response(
-          200,
-          ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
-          json_encode([
-            'versions' => [
-              [
-                'status' => 'poa',
-                'stage' => 'published',
-                'id' => '00001',
-                'version' => 1,
-                'type' => 'research-article',
-                'doi' => '10.7554/eLife.00001',
-                'title' => 'Article title',
-                'published' => '2010-01-01T00:00:00Z',
-                'versionDate' => '2010-01-01T00:00:00Z',
-                'statusDate' => '2010-01-01T00:00:00Z',
-                'volume' => 1,
-                'elocationId' => 'e00001',
-                'copyright' => [
-                  'license' => 'CC-BY-4.0',
-                  'holder' => 'Author One',
-                  'statement' => 'Copyright statement.',
-                ],
-                'authorLine' => 'Author One et al.',
+    $this->mockApiResponse(
+      new Request(
+        'GET',
+        'http://api.elifesciences.org/articles/00001',
+        ['Accept' => 'application/vnd.elife.article-poa+json; version=2, application/vnd.elife.article-vor+json; version=2']
+      ),
+      new Response(
+        200,
+        ['Content-Type' => 'application/vnd.elife.article-poa+json; version=2'],
+        json_encode([
+          'status' => 'poa',
+          'stage' => 'published',
+          'id' => '00001',
+          'version' => 1,
+          'type' => 'research-article',
+          'doi' => '10.7554/eLife.00001',
+          'title' => 'Article title',
+          'published' => '2010-01-01T00:00:00Z',
+          'versionDate' => '2010-01-01T00:00:00Z',
+          'statusDate' => '2010-01-01T00:00:00Z',
+          'volume' => 1,
+          'elocationId' => 'e00001',
+          'copyright' => [
+            'license' => 'CC-BY-4.0',
+            'holder' => 'Author One',
+            'statement' => 'Copyright statement.',
+          ],
+          'authorLine' => 'Author One et al.',
+          'authors' => [
+            [
+              'type' => 'person',
+              'name' => [
+                'preferred' => 'Author One',
+                'index' => 'Author One',
               ],
             ],
-          ])
-        )
-      );
+          ],
+          'reviewers' => [
+            [
+              'name' => [
+                'preferred' => 'Reviewer 1',
+                'index' => 'Reviewer 1',
+              ],
+              'role' => 'Reviewer',
+              'affiliations' => [
+                [
+                  'name' => ['Institution'],
+                  'address' => [
+                    'formatted' => ['Country'],
+                    'components' => [
+                      'country' => 'Country',
+                    ],
+                  ],
+                ],
+              ],
+            ],
+          ],
+        ])
+      )
+    );
 
-      $this->assertSame(200, $client->getResponse()->getStatusCode());
-      $this->assertNotContains('This research is available in a', array_map('trim', $crawler->filter('.info-bar')->extract(['_text'])));
+    $this->mockApiResponse(
+      new Request(
+        'GET',
+        'http://api.elifesciences.org/articles/00001/versions',
+        [
+          'Accept' => [
+            'application/vnd.elife.article-history+json; version=1',
+          ],
+        ]
+      ),
+      new Response(
+        200,
+        ['Content-Type' => 'application/vnd.elife.article-history+json; version=1'],
+        json_encode([
+          'versions' => [
+            [
+              'status' => 'poa',
+              'stage' => 'published',
+              'id' => '00001',
+              'version' => 1,
+              'type' => 'research-article',
+              'doi' => '10.7554/eLife.00001',
+              'title' => 'Article title',
+              'published' => '2010-01-01T00:00:00Z',
+              'versionDate' => '2010-01-01T00:00:00Z',
+              'statusDate' => '2010-01-01T00:00:00Z',
+              'volume' => 1,
+              'elocationId' => 'e00001',
+              'copyright' => [
+                'license' => 'CC-BY-4.0',
+                'holder' => 'Author One',
+                'statement' => 'Copyright statement.',
+              ],
+              'authorLine' => 'Author One et al.',
+            ],
+          ],
+        ])
+      )
+    );
 
-    }
+    $crawler = $client->request('GET', '/articles/00001');
 
+    $this->assertSame(200, $client->getResponse()->getStatusCode());
+    $this->assertNotContains('reproducible view',
+      array_map('trim', $crawler->filter('.info-bar')->eq(0)->extract(['_text'])));
+  }
     /**
      * @test
      */

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1370,6 +1370,7 @@ final class ArticleControllerTest extends PageTestCase
             array_map('trim', $crawler->filter('.info-bar')->eq(0)->extract(['_text']))
         );
     }
+
     /**
      * @test
      */

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1248,7 +1248,7 @@ final class ArticleControllerTest extends PageTestCase
     $crawler = $client->request('GET', '/articles/12345');
 
     $this->assertSame(200, $client->getResponse()->getStatusCode());
-    $this->assertContains('This research is available in a reproducible view',
+    $this->assertContains('This research is available in a reproducible view.',
       array_map('trim', $crawler->filter('.info-bar--warning')->extract(['_text'])));
   }
   /**


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4525

Since we don't want to expand the API yet for a single experiment, we feature flag zero or more article ids so that they will display a bar with a link to an external page with their `reproducible version`, a display of the article that allows to interact with figures and regenerate them by changing their source code.