### PR TITLE
Founding Editor-in-Chief may not be of type leadership

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To run a single scenario:
 docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci vendor/bin/behat features/article.feature
 ```
 
-If you have made changes to the code and want to re-run a test then you will rebuild your docker containers:
+If you have made changes to the code and want to re-run a test then you will need to rebuild your docker containers:
 
 ```
 docker-compose -f docker-compose.yml -f docker-compose.ci.yml down && docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --build --detach

--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci .ci/behat
 To run a single scenario:
 
 ```
-docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci vendor/bin/behat features/article.feature"
+docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci vendor/bin/behat features/article.feature
+```
+
+If you have made changes to the code and want to re-run a test then you will rebuild your docker containers:
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.ci.yml down && docker-compose -f docker-compose.yml -f docker-compose.ci.yml up --build --detach
 ```
 
 Reproduce a ci failure

--- a/features/bootstrap/PeopleContext.php
+++ b/features/bootstrap/PeopleContext.php
@@ -10,7 +10,6 @@ final class PeopleContext extends Context
     private $numberOfLeadershipPeople;
     private $numberOfSeniorEditors;
     private $numberOfReviewingEditors;
-    private $numberOfPeople;
 
     /**
      * @Given /^there is the MSA \'([^\']*)\'$/
@@ -90,8 +89,6 @@ final class PeopleContext extends Context
      */
     public function isTheFoundingEditorInChief(string $name)
     {
-        $this->numberOfPeople = 1;
-
         $id = '6d42f4fe';
 
         $person = [
@@ -468,24 +465,6 @@ final class PeopleContext extends Context
                 new Request(
                     'GET',
                     'http://api.elifesciences.org/people?page=1&per-page=1&order=asc&type[]=senior-editor',
-                    ['Accept' => 'application/vnd.elife.person-list+json; version=1']
-                ),
-                new Response(
-                    200,
-                    ['Content-Type' => 'application/vnd.elife.person-list+json; version=1'],
-                    json_encode([
-                        'total' => 0,
-                        'items' => [],
-                    ])
-                )
-            );
-        }
-
-        if (null === $this->numberOfPeople) {
-            $this->mockApiResponse(
-                new Request(
-                    'GET',
-                    'http://api.elifesciences.org/people?page=1&per-page=1&order=asc',
                     ['Accept' => 'application/vnd.elife.person-list+json; version=1']
                 ),
                 new Response(

--- a/features/bootstrap/PeopleContext.php
+++ b/features/bootstrap/PeopleContext.php
@@ -92,7 +92,7 @@ final class PeopleContext extends Context
     {
         $this->numberOfPeople = 1;
 
-        $id = $this->createId($name);
+        $id = '6d42f4fe';
 
         $person = [
             'id' => $id,
@@ -109,32 +109,13 @@ final class PeopleContext extends Context
         $this->mockApiResponse(
             new Request(
                 'GET',
-                'http://api.elifesciences.org/people?page=1&per-page=1&order=asc',
-                ['Accept' => 'application/vnd.elife.person-list+json; version=1']
+                'http://api.elifesciences.org/people/'.$id,
+                ['Accept' => 'application/vnd.elife.person+json; version=1']
             ),
             new Response(
                 200,
-                ['Content-Type' => 'application/vnd.elife.person-list+json; version=1'],
-                json_encode([
-                    'total' => 1,
-                    'items' => [$person],
-                ])
-            )
-        );
-
-        $this->mockApiResponse(
-            new Request(
-                'GET',
-                'http://api.elifesciences.org/people?page=1&per-page=100&order=asc',
-                ['Accept' => 'application/vnd.elife.person-list+json; version=1']
-            ),
-            new Response(
-                200,
-                ['Content-Type' => 'application/vnd.elife.person-list+json; version=1'],
-                json_encode([
-                    'total' => 1,
-                    'items' => [$person],
-                ])
+                ['Content-Type' => 'application/vnd.elife.person+json; version=1'],
+                json_encode($person)
             )
         );
     }

--- a/features/people-leadership.feature
+++ b/features/people-leadership.feature
@@ -12,6 +12,11 @@ Feature: People leadership team page
     When I go to the People page
     Then I should see Randy Schekman in the 'Editor-in-Chief' list
 
+  Scenario: Founding Editor-in-Chief appears last
+    Given Randy Schekman is the Founding Editor-in-Chief
+    When I go to the People page
+    Then I should see Randy Schekman in the 'Founding Editor-in-Chief' list
+
   Scenario: Deputy editors appears second
     Given there are deputy editors:
       | Forename | Surname |

--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -37,6 +37,8 @@ use function GuzzleHttp\Promise\promise_for;
 
 final class AboutController extends Controller
 {
+    const FOUNDING_EDITOR_IN_CHIEF_ID = '6d42f4fe';
+
     public function aboutAction(Request $request) : Response
     {
         $arguments = $this->aboutPageArguments($request);
@@ -271,14 +273,11 @@ final class AboutController extends Controller
                 $editorInChief = $leadership->filter(function (Person $person) {
                     return 'Editor-in-Chief' === $person->getTypeLabel();
                 });
-                // Load Founding Editor-in-Chief.
-                $foundingEditorInChief = $people->get('6d42f4fe')
+                $foundingEditorInChief = $people->get(self::FOUNDING_EDITOR_IN_CHIEF_ID)
                     ->then(function (Person $person) {
                         return new ArraySequence([$person]);
                     })
-                    ->otherwise(function () {
-                        return new EmptySequence();
-                    });
+                    ->otherwise($this->softFailure('Failed to load the Founding Editor-in-Chief', new EmptySequence()));
                 $deputyEditors = $leadership->filter(function (Person $person) {
                     return 'Editor-in-Chief' !== $person->getTypeLabel();
                 });

--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -270,11 +270,11 @@ final class AboutController extends Controller
                 $editorInChief = $leadership->filter(function (Person $person) {
                     return 'Editor-in-Chief' === $person->getTypeLabel();
                 });
-                $foundingEditorInChief = $leadership->filter(function (Person $person) {
+                $foundingEditorInChief = $people->filter(function (Person $person) {
                     return 'Founding Editor-in-Chief' === $person->getTypeLabel();
                 });
                 $deputyEditors = $leadership->filter(function (Person $person) {
-                    return !in_array($person->getTypeLabel(), ['Editor-in-Chief', 'Founding Editor-in-Chief']);
+                    return 'Editor-in-Chief' !== $person->getTypeLabel();
                 });
 
                 $arguments['lists'][] = $this->createAboutProfiles($editorInChief, 'Editor-in-Chief');

--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -2,6 +2,7 @@
 
 namespace eLife\Journal\Controller;
 
+use eLife\ApiSdk\Collection\ArraySequence;
 use eLife\ApiSdk\Collection\EmptySequence;
 use eLife\ApiSdk\Collection\PromiseSequence;
 use eLife\ApiSdk\Collection\Sequence;
@@ -270,9 +271,14 @@ final class AboutController extends Controller
                 $editorInChief = $leadership->filter(function (Person $person) {
                     return 'Editor-in-Chief' === $person->getTypeLabel();
                 });
-                $foundingEditorInChief = $people->filter(function (Person $person) {
-                    return 'Founding Editor-in-Chief' === $person->getTypeLabel();
-                });
+                // Load Founding Editor-in-Chief.
+                $foundingEditorInChief = $people->get('6d42f4fe')
+                    ->then(function (Person $person) {
+                        return new ArraySequence([$person]);
+                    })
+                    ->otherwise(function () {
+                        return new EmptySequence();
+                    });
                 $deputyEditors = $leadership->filter(function (Person $person) {
                     return 'Editor-in-Chief' !== $person->getTypeLabel();
                 });
@@ -280,7 +286,7 @@ final class AboutController extends Controller
                 $arguments['lists'][] = $this->createAboutProfiles($editorInChief, 'Editor-in-Chief');
                 $arguments['lists'][] = $this->createAboutProfiles($deputyEditors, 'Deputy editors');
                 $arguments['lists'][] = $this->createAboutProfiles($people->forType('senior-editor'), 'Senior editors');
-                $arguments['lists'][] = $this->createAboutProfiles($foundingEditorInChief, 'Founding Editor-in-Chief');
+                $arguments['lists'][] = $this->createAboutProfiles($foundingEditorInChief->wait(), 'Founding Editor-in-Chief');
                 break;
             case 'directors':
                 $arguments['title'] = 'Board of directors';

--- a/test/Controller/AboutPeopleControllerTest.php
+++ b/test/Controller/AboutPeopleControllerTest.php
@@ -193,7 +193,7 @@ final class AboutPeopleControllerTest extends PageTestCase
         $subject_filter = ($subject) ? '&subject[]='.$subject : '';
         foreach ($types as $type) {
             $type = implode('', array_map(function (string $type) {
-                return !empty($type) ? "&type[]={$type}" : '';
+                return "&type[]={$type}";
             }, (array) $type));
             $this->mockApiResponse(
                 new Request(

--- a/test/Controller/AboutPeopleControllerTest.php
+++ b/test/Controller/AboutPeopleControllerTest.php
@@ -184,7 +184,6 @@ final class AboutPeopleControllerTest extends PageTestCase
     protected function getUrl() : string
     {
         $this->mockPeopleApi(['leadership', 'senior-editor']);
-        $this->mockPeopleApi(['']);
 
         return '/about/people';
     }

--- a/test/Controller/AboutPeopleControllerTest.php
+++ b/test/Controller/AboutPeopleControllerTest.php
@@ -184,6 +184,7 @@ final class AboutPeopleControllerTest extends PageTestCase
     protected function getUrl() : string
     {
         $this->mockPeopleApi(['leadership', 'senior-editor']);
+        $this->mockPeopleApi(['']);
 
         return '/about/people';
     }
@@ -193,7 +194,7 @@ final class AboutPeopleControllerTest extends PageTestCase
         $subject_filter = ($subject) ? '&subject[]='.$subject : '';
         foreach ($types as $type) {
             $type = implode('', array_map(function (string $type) {
-                return "&type[]={$type}";
+                return !empty($type) ? "&type[]={$type}" : '';
             }, (array) $type));
             $this->mockApiResponse(
                 new Request(


### PR DESCRIPTION
Improves: https://github.com/elifesciences/issues/issues/4778

As a person can only have one type we need Randy Schekman to be considered an active BRE but be introduced as the Founding Editor-in-Chief in the leadership section. The best approach, without extending the schema to support multiple types, is to tag him as type `reviewing-editor` and to target his profile by his label `Founding Editor-in-Chief` in order to bring him into the leadership section on Journal.