### PR TITLE
Updated elife/patterns to ea2de3c: Updated pattern-library to 2c28073: Security: bumps highchart to 6.2.0 for CVE-2018-20801

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -910,12 +910,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "28c80b2b234659d608b6ad15094be5ea2a29bd09"
+                "reference": "ea2de3c284589802d33b6bd0d9fbc3ba3020f9ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/28c80b2b234659d608b6ad15094be5ea2a29bd09",
-                "reference": "28c80b2b234659d608b6ad15094be5ea2a29bd09",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/ea2de3c284589802d33b6bd0d9fbc3ba3020f9ab",
+                "reference": "ea2de3c284589802d33b6bd0d9fbc3ba3020f9ab",
                 "shasum": ""
             },
             "require": {
@@ -958,7 +958,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/master"
             },
-            "time": "2019-03-12T10:17:52+00:00"
+            "time": "2019-03-19T11:57:25+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/439/display/redirect which resulted in this pull request.