### PR TITLE
Push web image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ elifePipeline {
         elifeMainlineOnly {
             stage 'Push app image', {
                 DockerImage.elifesciences(this, "journal", commit).push()
+                DockerImage.elifesciences(this, "journal_web", commit).push()
             }
         }
     }

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -20,6 +20,7 @@ elifePipeline {
             elifeDeploySlackNotification 'journal', 'prod'
             node('containers-jenkins-plugin') {
                 DockerImage.elifesciences(this, "journal", commit).pull().tag('latest').push()
+                DockerImage.elifesciences(this, "journal_web", commit).pull().tag('latest').push()
             }
             builderDeployRevision 'journal--prod', commit, 'blue-green'
             builderSmokeTests 'journal--prod', '/srv/journal'


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/3676

The image contains assets in the `/srv/journal/web` folder that should be served directly by nginx rather than from the PHP application.