### PR TITLE
Fix sign up messages not appearing

### DIFF
--- a/src/EventListener/EndEmptySessionSubscriber.php
+++ b/src/EventListener/EndEmptySessionSubscriber.php
@@ -11,7 +11,7 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents() : array
     {
-        return [KernelEvents::RESPONSE => ['onKernelResponse', -1000]];
+        return [KernelEvents::RESPONSE => ['onKernelResponse', -127]]; # Before TestSessionListener
     }
 
     public function onKernelResponse(FilterResponseEvent $event)
@@ -23,11 +23,7 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $session = $request->getSession();
 
-        if (!$session || (!$session->isStarted() && !$request->hasPreviousSession()) || !empty($session->all())) {
-            return;
-        }
-
-        if ($session instanceof Session && !empty($session->getFlashBag()->peekAll())) {
+        if (!$session instanceof Session || !$session->isStarted() || !$session->isEmpty()) {
             return;
         }
 

--- a/src/EventListener/EndEmptySessionSubscriber.php
+++ b/src/EventListener/EndEmptySessionSubscriber.php
@@ -19,6 +19,12 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $response = $event->getResponse();
+
+        if ($response->headers->has('Set-Cookie')) {
+            return;
+        }
+
         $request = $event->getRequest();
         $session = $request->getSession();
 
@@ -28,7 +34,7 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
 
         if (empty($session->all())) {
             $session->invalidate();
-            $event->getResponse()->headers->clearCookie($session->getName());
+            $response->headers->clearCookie($session->getName());
         }
     }
 }

--- a/src/EventListener/EndEmptySessionSubscriber.php
+++ b/src/EventListener/EndEmptySessionSubscriber.php
@@ -27,7 +27,7 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (!$session->isEmpty()) {
+        if ($session->isEmpty()) {
             $session->invalidate();
             $event->getResponse()->headers->clearCookie($session->getName());
         }

--- a/src/EventListener/EndEmptySessionSubscriber.php
+++ b/src/EventListener/EndEmptySessionSubscriber.php
@@ -11,7 +11,7 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents() : array
     {
-        return [KernelEvents::RESPONSE => ['onKernelResponse', -127]]; // Before TestSessionListener
+        return [KernelEvents::RESPONSE => ['onKernelResponse', -1000]];
     }
 
     public function onKernelResponse(FilterResponseEvent $event)
@@ -23,11 +23,13 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
         $session = $request->getSession();
 
-        if (!$session instanceof Session || !$session->isStarted() || !$session->isEmpty()) {
+        if (!$session instanceof Session || (!$session->isStarted() && !$request->hasPreviousSession())) {
             return;
         }
 
-        $session->invalidate();
-        $event->getResponse()->headers->clearCookie($session->getName());
+        if (!$session->isEmpty()) {
+            $session->invalidate();
+            $event->getResponse()->headers->clearCookie($session->getName());
+        }
     }
 }

--- a/src/EventListener/EndEmptySessionSubscriber.php
+++ b/src/EventListener/EndEmptySessionSubscriber.php
@@ -11,7 +11,7 @@ final class EndEmptySessionSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents() : array
     {
-        return [KernelEvents::RESPONSE => ['onKernelResponse', -127]]; # Before TestSessionListener
+        return [KernelEvents::RESPONSE => ['onKernelResponse', -127]]; // Before TestSessionListener
     }
 
     public function onKernelResponse(FilterResponseEvent $event)


### PR DESCRIPTION
The empty session check in `EndEmptySessionSubscriber` ignores flash messages, so removes the cookie as soon as it's set so they don't appear.

Not been able to recreate the problem in tests (even with Selenium). Going to keep digging, but this initial commit would _hopefully_ get round it at least.