### PR TITLE
Fix publisher logo URL

### DIFF
--- a/app/Resources/views/article.html.twig
+++ b/app/Resources/views/article.html.twig
@@ -349,7 +349,7 @@
                 "name": "eLife Sciences Publications, Ltd",
                 "logo": {
                     "@type": "ImageObject",
-                    "url": "{{ absolute_url(asset('/assets/img/patterns/organisms/elife-logo-full-2x.png')) }}"
+                    "url": "{{ absolute_url(asset('assets/patterns/img/patterns/organisms/elife-logo-full-2x.png')) }}"
                 }
             },
             {% if item.keywords is defined and item.keywords|length %}


### PR DESCRIPTION
https://github.com/elifesciences/journal/pull/1187/commits/8103931ed6ae519af111a2ea4bbabf9543d5a3e6 broke the path to the logo. (The initial slash bypasses the asset location, but the path was wrong anyway. I thought there was an exception thrown if it could find it...)

/cc @discodavey 