### PR TITLE
Updated elife/patterns to 5668c7a: Updated pattern-library to be2890c: Change line height to allow for url underline

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -911,12 +911,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "97b63c6ee4e71f468b82c2deff27d546260ddd16"
+                "reference": "5668c7ac5d0f0a252002f019635dd1c09b19abc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/97b63c6ee4e71f468b82c2deff27d546260ddd16",
-                "reference": "97b63c6ee4e71f468b82c2deff27d546260ddd16",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/5668c7ac5d0f0a252002f019635dd1c09b19abc7",
+                "reference": "5668c7ac5d0f0a252002f019635dd1c09b19abc7",
                 "shasum": ""
             },
             "require": {
@@ -959,7 +959,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/master"
             },
-            "time": "2019-11-21T08:54:40+00:00"
+            "time": "2020-01-17T15:09:22+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/458/display/redirect which resulted in this pull request.