### PR TITLE
Introduce temporary wrapper for spacing

### DIFF
--- a/app/Resources/views/promotional-collection.html.twig
+++ b/app/Resources/views/promotional-collection.html.twig
@@ -8,7 +8,9 @@
 
     {{ render_pattern(contentHeader) }}
 
-    {# This is need to provide padding between the banner and listing #}
+    {# Temporary fix adds vertical whitespace between the bottom of a content header with an overlaid image credit, #}
+    {# and a following wrapper--listing element. #}
+    {# The long term fix is to update the pattern library to cater for this possibility. #}
     <div class="wrapper"></div>
 
     {% include 'calls-to-action.html.twig' %}

--- a/app/Resources/views/promotional-collection.html.twig
+++ b/app/Resources/views/promotional-collection.html.twig
@@ -8,15 +8,8 @@
 
     {{ render_pattern(contentHeader) }}
 
-    <div class="wrapper">
-
-        {% if contextualData %}
-
-            {{ render_pattern(contextualData) }}
-
-        {% endif %}
-
-    </div>
+    {# This is need to provide padding between the banner and listing #}
+    <div class="wrapper"></div>
 
     {% include 'calls-to-action.html.twig' %}
 

--- a/app/Resources/views/promotional-collection.html.twig
+++ b/app/Resources/views/promotional-collection.html.twig
@@ -8,6 +8,16 @@
 
     {{ render_pattern(contentHeader) }}
 
+    <div class="wrapper">
+
+        {% if contextualData %}
+
+            {{ render_pattern(contextualData) }}
+
+        {% endif %}
+
+    </div>
+
     {% include 'calls-to-action.html.twig' %}
 
     {% embed 'grid/listing-two-column.html.twig' %}

--- a/src/Controller/PromotionalCollectionsController.php
+++ b/src/Controller/PromotionalCollectionsController.php
@@ -3,11 +3,9 @@
 namespace eLife\Journal\Controller;
 
 use eLife\ApiSdk\Collection\Sequence;
-use eLife\ApiSdk\Model\Identifier;
 use eLife\ApiSdk\Model\PromotionalCollection;
 use eLife\Journal\Helper\Callback;
 use eLife\Patterns\ViewModel\ContentHeader;
-use eLife\Patterns\ViewModel\ContextualData;
 use eLife\Patterns\ViewModel\ListHeading;
 use eLife\Patterns\ViewModel\ListingProfileSnippets;
 use eLife\Patterns\ViewModel\ListingTeasers;

--- a/src/Controller/PromotionalCollectionsController.php
+++ b/src/Controller/PromotionalCollectionsController.php
@@ -3,9 +3,11 @@
 namespace eLife\Journal\Controller;
 
 use eLife\ApiSdk\Collection\Sequence;
+use eLife\ApiSdk\Model\Identifier;
 use eLife\ApiSdk\Model\PromotionalCollection;
 use eLife\Journal\Helper\Callback;
 use eLife\Patterns\ViewModel\ContentHeader;
+use eLife\Patterns\ViewModel\ContextualData;
 use eLife\Patterns\ViewModel\ListHeading;
 use eLife\Patterns\ViewModel\ListingProfileSnippets;
 use eLife\Patterns\ViewModel\ListingTeasers;
@@ -27,6 +29,8 @@ final class PromotionalCollectionsController extends Controller
 
         $arguments['title'] = $arguments['item']
             ->then(Callback::method('getTitle'));
+
+        $arguments['contextualData'] = null;
 
         $arguments['contentHeader'] = $arguments['item']
             ->then($this->willConvertTo(ContentHeader::class));

--- a/src/Controller/PromotionalCollectionsController.php
+++ b/src/Controller/PromotionalCollectionsController.php
@@ -28,8 +28,6 @@ final class PromotionalCollectionsController extends Controller
         $arguments['title'] = $arguments['item']
             ->then(Callback::method('getTitle'));
 
-        $arguments['contextualData'] = null;
-
         $arguments['contentHeader'] = $arguments['item']
             ->then($this->willConvertTo(ContentHeader::class));
 


### PR DESCRIPTION
This empty wrapper preserves the layout of the collection page which which the promotional collection is based upon. This is the quickest way to fix the issue and we can follow it up with a real fix later.

See: https://github.com/elifesciences/journal/blob/develop/app/Resources/views/collection.html.twig#L11-L19