### PR TITLE
Temporarily remove continuumtest and continuumtestpreview from automated deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,18 +81,19 @@ elifePipeline {
                         builderSmokeTests 'journal--demo', '/srv/journal'
                     }
                 },
-                continuumtest: {
-                    lock('journal--continuumtest') {
-                        builderDeployRevision 'journal--continuumtest', commit
-                        builderSmokeTests 'journal--continuumtest', '/srv/journal'
-                    }
-                },
-                continuumtestpreview: {
-                    lock('journal--continuumtestpreview') {
-                        builderDeployRevision 'journal--continuumtestpreview', commit
-                        builderSmokeTests 'journal--continuumtestpreview', '/srv/journal'
-                    }
-                }
+                // locked and currently used for journal-cms integration testing
+                //continuumtest: {
+                //    lock('journal--continuumtest') {
+                //        builderDeployRevision 'journal--continuumtest', commit
+                //        builderSmokeTests 'journal--continuumtest', '/srv/journal'
+                //    }
+                //},
+                //continuumtestpreview: {
+                //    lock('journal--continuumtestpreview') {
+                //        builderDeployRevision 'journal--continuumtestpreview', commit
+                //        builderSmokeTests 'journal--continuumtestpreview', '/srv/journal'
+                //    }
+                //},
             ]
             parallel deployments
         }


### PR DESCRIPTION
These environments will be used to test new journal-cms features that require deploying a branch like https://github.com/elifesciences/issues/issues/5374 and similar tickets.