### PR TITLE
Avoiding unsafe characters in download uri

### DIFF
--- a/src/Helper/DownloadLinkUriGenerator.php
+++ b/src/Helper/DownloadLinkUriGenerator.php
@@ -19,7 +19,7 @@ final class DownloadLinkUriGenerator
 
     public function generate(DownloadLink $link) : string
     {
-        $uri = $this->urlGenerator->generate('download', ['uri' => base64_encode($link->getUri()), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
+        $uri = $this->urlGenerator->generate('download', ['uri' => strtr(base64_encode($link->getUri()), '+/=', '._-'), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return $this->uriSigner->sign($uri);
     }
@@ -35,6 +35,6 @@ final class DownloadLinkUriGenerator
         $name = array_pop($path);
         $uri = array_pop($path);
 
-        return new DownloadLink(base64_decode($uri), $name);
+        return new DownloadLink(base64_decode(strtr($uri, '._-', '+/=')), $name);
     }
 }

--- a/src/Helper/DownloadLinkUriGenerator.php
+++ b/src/Helper/DownloadLinkUriGenerator.php
@@ -19,7 +19,7 @@ final class DownloadLinkUriGenerator
 
     public function generate(DownloadLink $link) : string
     {
-        $uri = $this->urlGenerator->generate('download', ['uri' => strtr(base64_encode($link->getUri()), '+/=', '._-'), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
+        $uri = $this->urlGenerator->generate('download', ['uri' => urlencode(base64_encode($link->getUri())), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return $this->uriSigner->sign($uri);
     }
@@ -35,6 +35,6 @@ final class DownloadLinkUriGenerator
         $name = array_pop($path);
         $uri = array_pop($path);
 
-        return new DownloadLink(base64_decode(strtr($uri, '._-', '+/=')), $name);
+        return new DownloadLink(base64_decode(urldecode($uri)), $name);
     }
 }

--- a/src/Helper/DownloadLinkUriGenerator.php
+++ b/src/Helper/DownloadLinkUriGenerator.php
@@ -19,7 +19,7 @@ final class DownloadLinkUriGenerator
 
     public function generate(DownloadLink $link) : string
     {
-        $uri = $this->urlGenerator->generate('download', ['uri' => urlencode(base64_encode($link->getUri())), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
+        $uri = $this->urlGenerator->generate('download', ['uri' => strtr(base64_encode($link->getUri()), '+/=', '._-'), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return $this->uriSigner->sign($uri);
     }
@@ -35,6 +35,6 @@ final class DownloadLinkUriGenerator
         $name = array_pop($path);
         $uri = array_pop($path);
 
-        return new DownloadLink(base64_decode(urldecode($uri)), $name);
+        return new DownloadLink(base64_decode(strtr($uri, '._-', '+/=')), $name);
     }
 }

--- a/src/Helper/DownloadLinkUriGenerator.php
+++ b/src/Helper/DownloadLinkUriGenerator.php
@@ -8,6 +8,9 @@ use UnexpectedValueException;
 
 final class DownloadLinkUriGenerator
 {
+    const URL_UNSAFE_CHARS = '+/=';
+    const URL_UNSAFE_REPLACES = '._-';
+
     private $urlGenerator;
     private $uriSigner;
 
@@ -19,7 +22,7 @@ final class DownloadLinkUriGenerator
 
     public function generate(DownloadLink $link) : string
     {
-        $uri = $this->urlGenerator->generate('download', ['uri' => strtr(base64_encode($link->getUri()), '+/=', '._-'), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
+        $uri = $this->urlGenerator->generate('download', ['uri' => strtr(base64_encode($link->getUri()), self::URL_UNSAFE_CHARS, self::URL_UNSAFE_REPLACES), 'name' => $link->getFilename()], UrlGeneratorInterface::ABSOLUTE_URL);
 
         return $this->uriSigner->sign($uri);
     }
@@ -35,6 +38,6 @@ final class DownloadLinkUriGenerator
         $name = array_pop($path);
         $uri = array_pop($path);
 
-        return new DownloadLink(base64_decode(strtr($uri, '._-', '+/=')), $name);
+        return new DownloadLink(base64_decode(strtr($uri, self::URL_UNSAFE_REPLACES, self::URL_UNSAFE_CHARS)), $name);
     }
 }

--- a/test/Helper/DownloadLinkUriGeneratorTest.php
+++ b/test/Helper/DownloadLinkUriGeneratorTest.php
@@ -44,7 +44,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     public function it_generates_a_uri()
     {
         $this->assertSame(
-            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar'),
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA--/foo.bar'),
             $this->downloadLinkUriGenerator->generate(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'))
         );
     }
@@ -54,8 +54,9 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
      */
     public function it_generates_a_uri_avoiding_unsafe_characters()
     {
+        // See: https://stackoverflow.com/questions/1374753/passing-base64-encoded-strings-in-url
         $this->assertSame(
-            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cHM6Ly9odWIuc3RlbmNpLmxhL2FwaS9wcm9qZWN0cy8xNzYvc25hcHNob3RzLzI%2FZm9ybWF0PXRhci5neg%3D%3D/foo.bar'),
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cHM6Ly9odWIuc3RlbmNpLmxhL2FwaS9wcm9qZWN0cy8xNzYvc25hcHNob3RzLzI_Zm9ybWF0PXRhci5neg--/foo.bar'),
             $this->downloadLinkUriGenerator->generate(new DownloadLink('https://hub.stenci.la/api/projects/176/snapshots/2?format=tar.gz', 'foo.bar'))
         );
     }
@@ -65,7 +66,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
      */
     public function it_checks_a_uri()
     {
-        $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar')));
+        $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA--/foo.bar')));
     }
 
     /**
@@ -75,6 +76,6 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->downloadLinkUriGenerator->check('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4da==?_hash=uCm1Z0B%2FIH9%2FKn3icYBFW9ZhmguDotpC0Lp4j2vXmB0%3D');
+        $this->downloadLinkUriGenerator->check('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4da--?_hash=uCm1Z0B%2FIH9%2FKn3icYBFW9ZhmguDotpC0Lp4j2vXmB0%3D');
     }
 }

--- a/test/Helper/DownloadLinkUriGeneratorTest.php
+++ b/test/Helper/DownloadLinkUriGeneratorTest.php
@@ -52,6 +52,18 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     /**
      * @test
      */
+    public function it_generates_a_uri_avoiding_unsafe_characters()
+    {
+        // See: https://stackoverflow.com/questions/1374753/passing-base64-encoded-strings-in-url
+        $this->assertSame(
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cHM6Ly9odWIuc3RlbmNpLmxhL2FwaS9wcm9qZWN0cy8xNzYvc25hcHNob3RzLzI_Zm9ybWF0PXRhci5neg--/foo.bar'),
+            $this->downloadLinkUriGenerator->generate(new DownloadLink('https://hub.stenci.la/api/projects/176/snapshots/2?format=tar.gz', 'foo.bar'))
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_checks_a_uri()
     {
         $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar')));

--- a/test/Helper/DownloadLinkUriGeneratorTest.php
+++ b/test/Helper/DownloadLinkUriGeneratorTest.php
@@ -44,7 +44,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     public function it_generates_a_uri()
     {
         $this->assertSame(
-            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA--/foo.bar'),
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar'),
             $this->downloadLinkUriGenerator->generate(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'))
         );
     }
@@ -54,9 +54,8 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
      */
     public function it_generates_a_uri_avoiding_unsafe_characters()
     {
-        // See: https://stackoverflow.com/questions/1374753/passing-base64-encoded-strings-in-url
         $this->assertSame(
-            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cHM6Ly9odWIuc3RlbmNpLmxhL2FwaS9wcm9qZWN0cy8xNzYvc25hcHNob3RzLzI_Zm9ybWF0PXRhci5neg--/foo.bar'),
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cHM6Ly9odWIuc3RlbmNpLmxhL2FwaS9wcm9qZWN0cy8xNzYvc25hcHNob3RzLzI%2FZm9ybWF0PXRhci5neg%3D%3D/foo.bar'),
             $this->downloadLinkUriGenerator->generate(new DownloadLink('https://hub.stenci.la/api/projects/176/snapshots/2?format=tar.gz', 'foo.bar'))
         );
     }
@@ -66,7 +65,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
      */
     public function it_checks_a_uri()
     {
-        $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA--/foo.bar')));
+        $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar')));
     }
 
     /**
@@ -76,6 +75,6 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->downloadLinkUriGenerator->check('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4da--?_hash=uCm1Z0B%2FIH9%2FKn3icYBFW9ZhmguDotpC0Lp4j2vXmB0%3D');
+        $this->downloadLinkUriGenerator->check('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4da==?_hash=uCm1Z0B%2FIH9%2FKn3icYBFW9ZhmguDotpC0Lp4j2vXmB0%3D');
     }
 }

--- a/test/Helper/DownloadLinkUriGeneratorTest.php
+++ b/test/Helper/DownloadLinkUriGeneratorTest.php
@@ -44,7 +44,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     public function it_generates_a_uri()
     {
         $this->assertSame(
-            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar'),
+            $this->uriSigner->sign($this->defaultBaseUrl.'/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA--/foo.bar'),
             $this->downloadLinkUriGenerator->generate(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'))
         );
     }
@@ -66,7 +66,7 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
      */
     public function it_checks_a_uri()
     {
-        $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA==/foo.bar')));
+        $this->assertEquals(new DownloadLink('http://www.example.com/test.txt', 'foo.bar'), $this->downloadLinkUriGenerator->check($this->uriSigner->sign('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4dA--/foo.bar')));
     }
 
     /**
@@ -76,6 +76,6 @@ final class DownloadLinkUriGeneratorTest extends KernelTestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->downloadLinkUriGenerator->check('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4da==?_hash=uCm1Z0B%2FIH9%2FKn3icYBFW9ZhmguDotpC0Lp4j2vXmB0%3D');
+        $this->downloadLinkUriGenerator->check('http://localhost/download/aHR0cDovL3d3dy5leGFtcGxlLmNvbS90ZXN0LnR4da--?_hash=uCm1Z0B%2FIH9%2FKn3icYBFW9ZhmguDotpC0Lp4j2vXmB0%3D');
     }
 }


### PR DESCRIPTION
Three of the base64 characters are not url safe:

valid: `ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=`

unsafe: `+/=`

A workaround is to substitute these unsafe characters for characters outside of valid `base64` characters and safely swap them back in before decoding.