### PR TITLE
Dynamic submit return from referrer

### DIFF
--- a/.docker/parameters.yml
+++ b/.docker/parameters.yml
@@ -11,15 +11,15 @@ parameters:
     mailer_username: ~
     mailer_password: ~
     mailer_encryption: ~
-    submit_url: https://xpub.elifesciences.org/
+    submit_url: https://submit.elifesciences.org/
+    submit_url_redirects:
+        - .*\.elifesciences.org$
     crm_url: https://crm.elifesciences.org/crm/civicrm/
     gtm_id: ~
     cookie_consent: false
     trusted_hosts:
-      - .*\.localhost$
-      - ^localhost$
-      - .*\.?web$
-      - ^web$
+      - localhost
+      - web
     status_checks:
         Articles: articles
     oauth2_client_id: some-id

--- a/.docker/parameters.yml
+++ b/.docker/parameters.yml
@@ -16,8 +16,10 @@ parameters:
     gtm_id: ~
     cookie_consent: false
     trusted_hosts:
-      - localhost
-      - web
+      - .*\.localhost$
+      - ^localhost$
+      - .*\.?web$
+      - ^web$
     status_checks:
         Articles: articles
     oauth2_client_id: some-id

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -14,6 +14,8 @@ parameters:
     mailer_password: ~
     mailer_encryption: ~
     submit_url: https://submit.elifesciences.org/
+    submit_url_redirects:
+        - .*\.elifesciences.org$
     crm_url: https://crm.elifesciences.org/crm/civicrm/
     gtm_id: ~
     cookie_consent: true

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -51,7 +51,7 @@ final class SubmitController extends Controller
 
             if (!$trusted) {
                 throw new NotFoundHttpException('Not allowed to see xPub');
-            } 
+            }
         }
 
         $redirectUrl = "{$returnUrl}#{$jwt}";

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -38,6 +38,7 @@ final class SubmitController extends Controller
         $returnUrl = $request->query->get('return_url', null);
 
         if (is_null($returnUrl)) {
+            // remove this case once libero reviewer is live and xpub retired
             $returnUrl = $this->getParameter('submit_url');
         } else {
             $allowedRedirects = $this->getParameter('submit_url_redirects');
@@ -56,6 +57,7 @@ final class SubmitController extends Controller
             }
         }
 
+        // remove this case once libero reviewer is live and xpub retired, only return token in query afterwards
         $redirectUrl = "{$returnUrl}#{$jwt}";
 
         // return in query arg if specified

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -46,8 +46,8 @@ final class SubmitController extends Controller
 
             foreach ($allowedRedirects as $allowed) {
                 if (preg_match('/'.$allowed.'/', $uri->getHost())) {
-                    echo 'allowed'.PHP_EOL;
                     $isAllowed = true;
+                    break;
                 }
             }
 

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Psr7\Uri;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -39,18 +40,19 @@ final class SubmitController extends Controller
         if (is_null($returnUrl)) {
             $returnUrl = $this->getParameter('submit_url');
         } else {
-            $trustedHosts = $this->getParameter('trusted_hosts');
-            $trusted = false;
-
+            $allowedRedirects = $this->getParameter('submit_url_redirects');
+            $isAllowed = false;
             $uri = new Uri($returnUrl);
-            foreach ($trustedHosts as $trustedHost) {
-                if (preg_match("/{$trustedHost}/", $uri->getHost())) {
-                    $trusted = true;
+
+            foreach ($allowedRedirects as $allowed) {
+                if (preg_match('/'.$allowed.'/', $uri->getHost())) {
+                    echo 'allowed'.PHP_EOL;
+                    $isAllowed = true;
                 }
             }
 
-            if (!$trusted) {
-                throw new NotFoundHttpException('Not allowed to see xPub');
+            if (!$isAllowed) {
+                throw new BadRequestHttpException();
             }
         }
 

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -2,6 +2,7 @@
 
 namespace eLife\Journal\Controller;
 
+use GuzzleHttp\Psr7\Uri;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -40,9 +41,10 @@ final class SubmitController extends Controller
         } else {
             $trustedHosts = $this->getParameter('trusted_hosts');
             $trusted = false;
-
+            
+            $uri = new Uri($returnUrl);
             foreach ($trustedHosts as $trustedHost) {
-                if (preg_match("/{$trustedHost}/", $returnUrl)) {
+                if (preg_match("/{$trustedHost}/", $uri->getHost())) {
                     $trusted = true;
                 }
             }
@@ -55,7 +57,7 @@ final class SubmitController extends Controller
         $redirectUrl = "{$returnUrl}#{$jwt}";
 
         // return in query arg if specified
-        $tokenInQueryArg = $request->query->get('token_in_query_arg', false);
+        $tokenInQueryArg = $request->query->get('token_in_query', false);
 
         if ($tokenInQueryArg) {
             $info = parse_url($returnUrl);

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -41,7 +41,7 @@ final class SubmitController extends Controller
         } else {
             $trustedHosts = $this->getParameter('trusted_hosts');
             $trusted = false;
-            
+
             $uri = new Uri($returnUrl);
             foreach ($trustedHosts as $trustedHost) {
                 if (preg_match("/{$trustedHost}/", $uri->getHost())) {

--- a/src/Controller/SubmitController.php
+++ b/src/Controller/SubmitController.php
@@ -60,11 +60,7 @@ final class SubmitController extends Controller
         $tokenInQueryArg = $request->query->get('token_in_query', false);
 
         if ($tokenInQueryArg) {
-            $info = parse_url($returnUrl);
-            parse_str($info['query'] ?? '', $query);
-
-            $httpQuery = http_build_query(array_merge($query, ['token' => $jwt]));
-            $redirectUrl = $info['scheme'] . '://' . $info['host'] . $info['path'] . '?' . $httpQuery;
+            $redirectUrl = Uri::withQueryValue(new Uri($returnUrl), 'token', $jwt);
         }
 
         return new RedirectResponse($redirectUrl);

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -2,9 +2,9 @@
 
 namespace test\eLife\Journal;
 
+use function GuzzleHttp\Psr7\uri_for;
 use GuzzleHttp\Psr7\UriNormalizer;
 use Psr\Http\Message\UriInterface;
-use function GuzzleHttp\Psr7\uri_for;
 
 trait Assertions
 {

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -2,9 +2,9 @@
 
 namespace test\eLife\Journal;
 
-use function GuzzleHttp\Psr7\uri_for;
 use GuzzleHttp\Psr7\UriNormalizer;
 use Psr\Http\Message\UriInterface;
+use function GuzzleHttp\Psr7\uri_for;
 
 trait Assertions
 {

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -21,18 +21,4 @@ trait Assertions
 
         $this->assertEquals($normalizedExpected, $normalizedActual, $message);
     }
-
-    /**
-     * @param string|UriInterface $expected
-     * @param string|UriInterface $actual
-     */
-    final protected function assertUriStartsWith($expected, $actual, string $message = '')
-    {
-        $flags = UriNormalizer::PRESERVING_NORMALIZATIONS | UriNormalizer::SORT_QUERY_PARAMETERS;
-
-        $normalizedExpected = UriNormalizer::normalize(uri_for($expected), $flags)->__toString();
-        $normalizedActual = UriNormalizer::normalize(uri_for($actual), $flags)->__toString();
-
-        $this->assertStringStartsWith($normalizedExpected, $normalizedActual, $message);
-    }
 }

--- a/test/Assertions.php
+++ b/test/Assertions.php
@@ -21,4 +21,18 @@ trait Assertions
 
         $this->assertEquals($normalizedExpected, $normalizedActual, $message);
     }
+
+    /**
+     * @param string|UriInterface $expected
+     * @param string|UriInterface $actual
+     */
+    final protected function assertUriStartsWith($expected, $actual, string $message = '')
+    {
+        $flags = UriNormalizer::PRESERVING_NORMALIZATIONS | UriNormalizer::SORT_QUERY_PARAMETERS;
+
+        $normalizedExpected = UriNormalizer::normalize(uri_for($expected), $flags)->__toString();
+        $normalizedActual = UriNormalizer::normalize(uri_for($actual), $flags)->__toString();
+
+        $this->assertStringStartsWith($normalizedExpected, $normalizedActual, $message);
+    }
 }

--- a/test/Controller/SubmitControllerTest.php
+++ b/test/Controller/SubmitControllerTest.php
@@ -3,9 +3,9 @@
 namespace test\eLife\Journal\Controller;
 
 use Firebase\JWT\JWT;
-use function GuzzleHttp\Psr7\parse_query;
 use GuzzleHttp\Psr7\Uri;
 use test\eLife\Journal\WebTestCase;
+use function GuzzleHttp\Psr7\parse_query;
 
 /**
  * @backupGlobals enabled

--- a/test/Controller/SubmitControllerTest.php
+++ b/test/Controller/SubmitControllerTest.php
@@ -3,10 +3,9 @@
 namespace test\eLife\Journal\Controller;
 
 use Firebase\JWT\JWT;
+use function GuzzleHttp\Psr7\parse_query;
 use GuzzleHttp\Psr7\Uri;
 use test\eLife\Journal\WebTestCase;
-use function GuzzleHttp\Psr7\parse_query;
-use function GuzzleHttp\Psr7\uri_for;
 
 /**
  * @backupGlobals enabled
@@ -101,7 +100,7 @@ final class SubmitControllerTest extends WebTestCase
         $client = static::createClient();
         $this->logIn($client);
 
-        $client->request('GET', '/submit?return_url=' . urlencode('http://localhost/path?query=arg'));
+        $client->request('GET', '/submit?return_url='.urlencode('http://localhost/path?query=arg'));
         $response = $client->getResponse();
 
         $this->assertTrue($response->isRedirect());
@@ -122,7 +121,7 @@ final class SubmitControllerTest extends WebTestCase
         $client = static::createClient();
         $this->logIn($client);
 
-        $client->request('GET', '/submit?return_url=' . urlencode('http://localhost/path?query=arg') . '&token_in_query=true');
+        $client->request('GET', '/submit?return_url='.urlencode('http://localhost/path?query=arg').'&token_in_query=true');
         $response = $client->getResponse();
 
         $this->assertTrue($response->isRedirect());
@@ -144,14 +143,13 @@ final class SubmitControllerTest extends WebTestCase
         $client = static::createClient();
         $this->logIn($client);
 
-        $client->request('GET', '/submit?return_url=' . urlencode('http://localhostevil/path?query=arg') . '&token_in_query=true');
+        $client->request('GET', '/submit?return_url='.urlencode('http://localhostevil/path?query=arg').'&token_in_query=true');
 
         $this->assertSame(404, $client->getResponse()->getStatusCode());
 
-        $client->request('GET', '/submit?return_url=' . urlencode('http://evillocalhost/path?query=arg') . '&token_in_query=true');
+        $client->request('GET', '/submit?return_url='.urlencode('http://evillocalhost/path?query=arg').'&token_in_query=true');
 
         $this->assertSame(404, $client->getResponse()->getStatusCode());
-
     }
 
     protected static function createClient(array $options = [], array $server = [])


### PR DESCRIPTION
New PR as [original branch](https://github.com/elifesciences/journal/pull/1269) name leads to pipeline [failure](https://alfred.elifesciences.org/blue/organizations/jenkins/pull-requests-projects%2Fjournal/detail/PR-1269/9/pipeline).

closes libero/reviewer#837

  -  uses return_url query arg to redirect to trusted url
  -  uses token_in_query_arg query arg to return the token in token query arg instead of fragment
    updates tests
