### PR TITLE
Rename era download file to elife-[article-id]-v[version-no]-era

### DIFF
--- a/src/ViewModel/Converter/ArticleDownloadLinksListConverter.php
+++ b/src/ViewModel/Converter/ArticleDownloadLinksListConverter.php
@@ -58,7 +58,7 @@ final class ArticleDownloadLinksListConverter implements ViewModelConverter
             $downloads[] = new ViewModel\ArticleDownloadLink(
                 new ViewModel\Link(
                     'Executable version',
-                    $this->downloadLinkUriGenerator->generate(DownloadLink::fromUri($context['rds-download'])),
+                    $this->downloadLinkUriGenerator->generate(new DownloadLink($context['rds-download'], preg_replace('/^[^\.]+/', sprintf('elife-%s-v%d-era', $object->getId(), $object->getVersion()), DownloadLink::fromUri($context['rds-download'])->getFilename()))),
                     false,
                     ['article-identifier' => $object->getDoi(), 'download-type' => 'rds-download']
                 ),

--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -1472,6 +1472,7 @@ final class ArticleControllerTest extends PageTestCase
         );
         $this->assertNotEmpty($crawler->filter('.article-download-links-list__link')->selectLink('Executable version'));
         $this->assertNotEmpty($crawler->filter('.article-download-links-list__secondary_link')->selectLink('What are executable versions?'));
+        $this->assertContains('/elife-id-of-article-with-rds-v3-era.dar', $crawler->filter('.article-download-links-list__link')->selectLink('Executable version')->attr('href'));
         $this->assertContains('Executable code', $crawler->filter('.view-selector')->text());
     }
 


### PR DESCRIPTION
This will alter the download filename of the `Executable version`.