### PR TITLE
Remove hypothesis services icon

### DIFF
--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -263,8 +263,7 @@
               services: [{
                 apiUrl: '{{ hypothesis_api }}',
                 authority: '{{ hypothesis_authority }}',
-                grantToken: {% if app.user %}'{{ hypothesis_token(app.user) }}'{% else %}null{% endif %},
-                icon: '{{ absolute_url(asset('assets/favicons/favicon.svg')) }}?1'
+                grantToken: {% if app.user %}'{{ hypothesis_token(app.user) }}'{% else %}null{% endif %}
                   {%- if not app.user %},
                 onLoginRequest: function () {
                   window.location.assign('{{ path('log-in') }}');

--- a/app/Resources/views/page.html.twig
+++ b/app/Resources/views/page.html.twig
@@ -264,7 +264,7 @@
                 apiUrl: '{{ hypothesis_api }}',
                 authority: '{{ hypothesis_authority }}',
                 grantToken: {% if app.user %}'{{ hypothesis_token(app.user) }}'{% else %}null{% endif %},
-                icon: '{{ absolute_url(asset('assets/favicons/favicon.svg')) }}'
+                icon: '{{ absolute_url(asset('assets/favicons/favicon.svg')) }}?1'
                   {%- if not app.user %},
                 onLoginRequest: function () {
                   window.location.assign('{{ path('log-in') }}');


### PR DESCRIPTION
The icon is ignored and the logo is drawn from the elifesciences.org authority hosted with hypothesis