### PR TITLE
Updated elife/patterns to 0ce61cb: Updated pattern-library to 0c692ad: Remove capitalize on article meta

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1235,12 +1235,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "90338de94bec6407dadba1ab1c734a3433f67fd2"
+                "reference": "0ce61cbb43ffbc05daf3cf0b2c44ce82444d0dfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/90338de94bec6407dadba1ab1c734a3433f67fd2",
-                "reference": "90338de94bec6407dadba1ab1c734a3433f67fd2",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/0ce61cbb43ffbc05daf3cf0b2c44ce82444d0dfa",
+                "reference": "0ce61cbb43ffbc05daf3cf0b2c44ce82444d0dfa",
                 "shasum": ""
             },
             "require": {
@@ -1283,7 +1283,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/master"
             },
-            "time": "2020-09-14T09:16:05+00:00"
+            "time": "2020-09-17T09:53:10+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/488/display/redirect which resulted in this pull request.