### PR TITLE
Updated elife/patterns to 12ccedf: Updated pattern-library to 88134b8: Remove check for hypothesis services icon

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1235,12 +1235,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "0ce61cbb43ffbc05daf3cf0b2c44ce82444d0dfa"
+                "reference": "12ccedf5adb165f7381b8c4c2e18a54b329ae4c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/0ce61cbb43ffbc05daf3cf0b2c44ce82444d0dfa",
-                "reference": "0ce61cbb43ffbc05daf3cf0b2c44ce82444d0dfa",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/12ccedf5adb165f7381b8c4c2e18a54b329ae4c1",
+                "reference": "12ccedf5adb165f7381b8c4c2e18a54b329ae4c1",
                 "shasum": ""
             },
             "require": {
@@ -1283,7 +1283,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/master"
             },
-            "time": "2020-09-17T09:53:10+00:00"
+            "time": "2020-09-21T10:02:35+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/490/display/redirect which resulted in this pull request.