### PR TITLE
Updated elife/patterns to 65849f2: Updated pattern-library to 50ea381: Revert "Add word-break for long urls" (#777)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1236,12 +1236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "a57f4571bb3a3c2c8a15a730db395d1f822c5f45"
+                "reference": "65849f299ca401a44355525f9d5ddb8ac3746dc0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/a57f4571bb3a3c2c8a15a730db395d1f822c5f45",
-                "reference": "a57f4571bb3a3c2c8a15a730db395d1f822c5f45",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/65849f299ca401a44355525f9d5ddb8ac3746dc0",
+                "reference": "65849f299ca401a44355525f9d5ddb8ac3746dc0",
                 "shasum": ""
             },
             "require": {
@@ -1284,7 +1284,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/master"
             },
-            "time": "2020-12-17T10:02:08+00:00"
+            "time": "2020-12-17T13:09:40+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/512/display/redirect which resulted in this pull request.