### PR TITLE
Always display additional assets

### DIFF
--- a/src/ViewModel/Converter/Block/CreatesAssetViewerInline.php
+++ b/src/ViewModel/Converter/Block/CreatesAssetViewerInline.php
@@ -17,7 +17,7 @@ trait CreatesAssetViewerInline
         $assetViewModel = $this->createCaptionedAsset($assetViewModel, $asset->getAsset(), $this->createDoi($asset));
 
         $additionalAssets = $asset->getSourceData()->map(function (AssetFile $sourceData) {
-          return $this->getViewModelConverter()->convert($sourceData);
+            return $this->getViewModelConverter()->convert($sourceData);
         })->toArray();
 
         if (!empty($context['parentId']) && !empty($context['ordinal'])) {

--- a/src/ViewModel/Converter/Block/CreatesAssetViewerInline.php
+++ b/src/ViewModel/Converter/Block/CreatesAssetViewerInline.php
@@ -16,13 +16,9 @@ trait CreatesAssetViewerInline
     {
         $assetViewModel = $this->createCaptionedAsset($assetViewModel, $asset->getAsset(), $this->createDoi($asset));
 
-        if (!empty($context['complete'])) {
-            $additionalAssets = $asset->getSourceData()->map(function (AssetFile $sourceData) {
-                return $this->getViewModelConverter()->convert($sourceData);
-            })->toArray();
-        } else {
-            $additionalAssets = [];
-        }
+        $additionalAssets = $asset->getSourceData()->map(function (AssetFile $sourceData) {
+          return $this->getViewModelConverter()->convert($sourceData);
+        })->toArray();
 
         if (!empty($context['parentId']) && !empty($context['ordinal'])) {
             return ViewModel\AssetViewerInline::supplement($asset->getAsset()->getId(), $context['ordinal'], $context['parentId'], $asset->getLabel(), $assetViewModel, $additionalAssets, $download, $open);

--- a/src/ViewModel/Converter/Block/CreatesAssetViewerInline.php
+++ b/src/ViewModel/Converter/Block/CreatesAssetViewerInline.php
@@ -25,7 +25,7 @@ trait CreatesAssetViewerInline
         }
 
         if (empty($context['complete']) && !empty($context['figuresUri'])) {
-            $seeAllLink = $context['figuresUri'].'#'.$asset->getAsset()->getId();
+            $seeAllLink = explode('#', $context['figuresUri'])[0].'#'.$asset->getAsset()->getId();
         } else {
             $seeAllLink = null;
         }

--- a/test/Controller/DoiControllerTest.php
+++ b/test/Controller/DoiControllerTest.php
@@ -81,7 +81,7 @@ final class DoiControllerTest extends WebTestCase
         return $this->arrayProvider([
             '10.7554/eLife.00001.001' => '/articles/00001#abstract',
             '10.7554/eLife.00001.002' => '/articles/00001#image1',
-            '10.7554/eLife.00001.003' => '/articles/00001/figures#image1-sd1',
+            '10.7554/eLife.00001.003' => '/articles/00001#image1-sd1',
             '10.7554/eLife.00001.004' => '/articles/00001/figures#image1s1',
             '10.7554/eLife.00001.005' => '/articles/00001/figures#image1s1-sd1',
         ]);


### PR DESCRIPTION
If a figure has no supplements the source data is not being shown.

Initially, I thought this could be resolved by exposing a `see all` link for all figures with source data but there is no reason why the source data for the first figure in the asset viewer shouldn't be displayed without the need for an additional http request.