### PR TITLE
Add test for see all link on figures with supplements

### DIFF
--- a/test/Controller/ArticleControllerTest.php
+++ b/test/Controller/ArticleControllerTest.php
@@ -2166,6 +2166,7 @@ final class ArticleControllerTest extends PageTestCase
 
         $this->assertSame('Body text', $body->eq(0)->text());
         $this->assertSame('Image 1 label with 1 supplement see all', trim($body->eq(1)->filter('.asset-viewer-inline__header_text')->text()));
+        $this->assertSame('/articles/00001/figures#image1', $body->eq(1)->filter('.asset-viewer-inline__header_link')->attr('href'));
 
         $appendix = $crawler->filter('.grid-column > section:nth-of-type(4)');
         $this->assertSame('Appendix 1', $appendix->filter('header > h2')->text());


### PR DESCRIPTION
This was fixed with https://github.com/elifesciences/journal/pull/1424/commits/33b60a779c4890a1af2b2abb4d11affc681f9f1e

This test protects against regression. Prior to the fix the `figuresUri` which possibly contains a fragment id was just used without any attempt to remove the fragment id. This test would have protected us from introducing that bug:

```
There was 1 failure:

1) test\eLife\Journal\Controller\ArticleControllerTest::it_displays_content
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/articles/00001/figures#image1'
+'/articles/00001/figures#figures-and-data#image1'

/srv/journal/test/Controller/ArticleControllerTest.php:2169
```