### PR TITLE
Allow slow connection to search but only implement on the search page

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -30,6 +30,13 @@ csa_guzzle:
                 headers:
                     Authorization: '%api_key%'
                 timeout: '%api_timeout%'
+        elife_api_slow:
+            config:
+                base_uri: '%api_url%'
+                connect_timeout: '%api_connect_timeout_slow%'
+                headers:
+                    Authorization: '%api_key%'
+                timeout: '%api_timeout_slow%'
         elife_crm:
             config:
                 base_uri: '%crm_url%'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -8,6 +8,11 @@ services:
         arguments:
           - '@csa_guzzle.client.elife_api'
 
+    elife.api_client.client.slow:
+        class: eLife\ApiClient\HttpClient\Guzzle6HttpClient
+        arguments:
+          - '@csa_guzzle.client.elife_api_slow'
+
     elife.api_client.client.warning_checking:
         class: eLife\ApiClient\HttpClient\WarningCheckingHttpClient
         decorates: elife.api_client.client
@@ -27,6 +32,12 @@ services:
         public: false
         arguments:
           - '@elife.api_client.client'
+
+    elife.api_sdk.slow:
+        class: eLife\ApiSdk\ApiSdk
+        public: false
+        arguments:
+          - '@elife.api_client.client.slow'
 
     elife.api_sdk.serializer:
         class: Symfony\Component\Serializer\Serializer
@@ -119,6 +130,10 @@ services:
     elife.api_sdk.search:
         class: eLife\ApiSdk\Client\Search
         factory: ['@elife.api_sdk', search]
+
+    elife.api_sdk.search.slow:
+        class: eLife\ApiSdk\Client\Search
+        factory: ['@elife.api_sdk.slow', search]
 
     elife.api_sdk.subjects:
         class: eLife\ApiSdk\Client\Subjects

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -78,7 +78,7 @@ final class SearchController extends Controller
             $apiTypes = array_merge($apiTypes, self::$researchTypes);
         }
 
-        $search = $this->get('elife.api_sdk.search')
+        $search = $this->get('elife.api_sdk.search.slow')
             ->forQuery($arguments['query']['for'])
             ->forSubject(...$arguments['query']['subjects'])
             ->forType(...$apiTypes)


### PR DESCRIPTION
This is a possible solution for https://github.com/elifesciences/issues/issues/6544

Since we have adjusted the boosting in search we have found that some queries are taking too long to execute and trigger timeout errors. We should increase the timeout on the PHP search application and then really on journal as a client of the search API to determine the timeout threshold. This would also allow us to see how long some of the more intensive queries are taking.