### PR TITLE
Allow call to action to be dismissible

### DIFF
--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -208,7 +208,8 @@ abstract class Controller implements ContainerAwareInterface
                 );
             },
             array_filter(
-                $this->getParameter('calls_to_action'),
+                // Limit of one call to action until we resolve issues of multiple calls to action.
+                array_slice($this->getParameter('calls_to_action'), 0, 1),
                 function (array $callToAction) use ($request) : bool {
                     if (isset($callToAction['from']) && time() < $callToAction['from']) {
                         return false;

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -2,6 +2,7 @@
 
 namespace eLife\Journal\Controller;
 
+use DateTimeImmutable;
 use eLife\ApiClient\Exception\BadResponse;
 use eLife\ApiSdk\Model\Image;
 use eLife\Journal\Exception\EarlyResponse;
@@ -202,7 +203,8 @@ abstract class Controller implements ContainerAwareInterface
                     ),
                     $callToAction['text'],
                     ViewModel\Button::link($callToAction['button']['text'], $callToAction['button']['path']),
-                    $callToAction['needsJs'] ?? false
+                    $callToAction['needsJs'] ?? false,
+                    !empty($callToAction['dismissible']['cookieExpires']) ? new DateTimeImmutable($callToAction['dismissible']['cookieExpires']) : null
                 );
             },
             array_filter(

--- a/test/Controller/PageTestCase.php
+++ b/test/Controller/PageTestCase.php
@@ -33,9 +33,9 @@ abstract class PageTestCase extends WebTestCase
 
         $callsToAction = $crawler->filter('.call-to-action');
 
-        $this->assertCount(2, $callsToAction);
+        // Call to actions are limited to 1 until we resolve issues with display of multiple.
+        $this->assertCount(1, $callsToAction);
         $this->assertContains('Call to action 1', $callsToAction->eq(0)->text());
-        $this->assertContains('Call to action 4', $callsToAction->eq(1)->text());
     }
 
     /**


### PR DESCRIPTION
This will need more attention if more than one call to action is displayed.

Journal is supposed to be able to handle multiple calls to action but the behaviour is strange when you have more than one. Particularly more than one that is dismissible.

This should be solved first in pattern-library but this should work fine for a single call to action.