### PR TITLE
fix: npm fails to fetch pre-built binary for libvips with http 403

### DIFF
--- a/Dockerfile.assets_builder
+++ b/Dockerfile.assets_builder
@@ -4,6 +4,10 @@ FROM elifesciences/journal_composer:${image_tag} AS composer
 FROM elifesciences/journal_npm:${image_tag} as npm
 FROM node:${node_version}
 
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    libvips \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=npm /node_modules/ node_modules/
 
 COPY assets/images/ assets/images/

--- a/Dockerfile.critical_css
+++ b/Dockerfile.critical_css
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libgtk-3-0 \
     libnspr4 \
     libnss3 \
-    libx11-xcb1 \
+    libvips \
     libxcomposite1 \
     libxcursor1 \
     libxdamage1 \

--- a/Dockerfile.critical_css
+++ b/Dockerfile.critical_css
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libnspr4 \
     libnss3 \
     libvips \
+    libx11-xcb1 \
     libxcomposite1 \
     libxcursor1 \
     libxdamage1 \

--- a/Dockerfile.npm
+++ b/Dockerfile.npm
@@ -3,6 +3,7 @@ FROM node:${node_version} as npm
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
     nasm \
+    libvips-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY npm-shrinkwrap.json \


### PR DESCRIPTION
Issue is that the currently hosted location for the pre-built binary is on a rate limited server, hence when the rate is hit you get 403 errors returned. We shouldn't be relying on npm dependencies to install prebuilt libraries, and should be using those available on the host OS.
This will only fix the issue on CI, trying to run `npm install` locally will still hit the same problem. Updating `gulp-responsive` to use `sharp >= 0.19.0` is required, which works. But `phantomjs-prebuilt` also has the same problem and updating that to version 0.19.0 or greater doesn't work, and `phantomjs` is now deprecated and has been for years.
This patches the problem, but the whole build system here in the Journal project needs a top to bottom review and cleanup

This fixes elifesciences/issues#6665