### PR TITLE
fix: update links in alert pages

### DIFF
--- a/src/Controller/AlertsController.php
+++ b/src/Controller/AlertsController.php
@@ -38,18 +38,18 @@ final class AlertsController extends Controller
             )),
             ArticleSection::basic('Community-building', 2, $this->render(
                 Listing::unordered([
-                    '<a href="https://crm.elifesciences.org/crm/community-news">Sign up to our monthly community newsletter</a> for details on upcoming webinars, travel grant deadlines, interviews, and other efforts to connect and support especially early-career researchers in life sciences and biomedicine',
+                    '<a href="https://elifesciences.org/content-alerts">Sign up to our monthly community newsletter</a> for details on upcoming webinars, travel grant deadlines, interviews, and other efforts to connect and support especially early-career researchers in life sciences and biomedicine',
                 ], 'bullet')
             )),
             ArticleSection::basic('eLife&apos;s Innovation Initiative and technology news', 2, $this->render(
                 Listing::unordered([
-                    'For the latest in eLife Labs, innovation, and new tools, <a href="https://crm.elifesciences.org/crm/node/8">sign up for our technology and innovation newsletter</a>',
+                    'For the latest in eLife Labs, innovation, and new tools, <a href="https://elifesciences.org/content-alerts">sign up for our technology and innovation newsletter</a>',
                     'Subscribe to the RSS feed for <a href="'.$this->get('router')->generate('rss-labs').'">all the open source technology innovation news</a> from eLife Sciences',
                 ], 'bullet')
             )),
             ArticleSection::basic('The latest from eLife', 2, $this->render(
                 Listing::unordered([
-                    'Sign up to receive our <a href="https://crm.elifesciences.org/crm/elife-news">bi-monthly newsletter</a> for recent developments at eLife, new products and collaborations and changes to editorial policy.</a>',
+                    'Sign up to receive our <a href="https://elifesciences.org/content-alerts">bi-monthly newsletter</a> for recent developments at eLife, new products and collaborations and changes to editorial policy.</a>',
                 ], 'bullet')
             )),
         ];

--- a/src/Controller/AlertsController.php
+++ b/src/Controller/AlertsController.php
@@ -38,18 +38,18 @@ final class AlertsController extends Controller
             )),
             ArticleSection::basic('Community-building', 2, $this->render(
                 Listing::unordered([
-                    '<a href="https://elifesciences.org/content-alerts">Sign up to our monthly community newsletter</a> for details on upcoming webinars, travel grant deadlines, interviews, and other efforts to connect and support especially early-career researchers in life sciences and biomedicine',
+                    '<a href="'.$this->get('router')->generate('content-alerts').'">Sign up to our monthly community newsletter</a> for details on upcoming webinars, travel grant deadlines, interviews, and other efforts to connect and support especially early-career researchers in life sciences and biomedicine',
                 ], 'bullet')
             )),
             ArticleSection::basic('eLife&apos;s Innovation Initiative and technology news', 2, $this->render(
                 Listing::unordered([
-                    'For the latest in eLife Labs, innovation, and new tools, <a href="https://elifesciences.org/content-alerts">sign up for our technology and innovation newsletter</a>',
+                    'For the latest in eLife Labs, innovation, and new tools, <a href="'.$this->get('router')->generate('content-alerts').'">sign up for our technology and innovation newsletter</a>',
                     'Subscribe to the RSS feed for <a href="'.$this->get('router')->generate('rss-labs').'">all the open source technology innovation news</a> from eLife Sciences',
                 ], 'bullet')
             )),
             ArticleSection::basic('The latest from eLife', 2, $this->render(
                 Listing::unordered([
-                    'Sign up to receive our <a href="https://elifesciences.org/content-alerts">bi-monthly newsletter</a> for recent developments at eLife, new products and collaborations and changes to editorial policy.</a>',
+                    'Sign up to receive our <a href="'.$this->get('router')->generate('content-alerts').'">bi-monthly newsletter</a> for recent developments at eLife, new products and collaborations and changes to editorial policy.</a>',
                 ], 'bullet')
             )),
         ];

--- a/src/Controller/AlertsController.php
+++ b/src/Controller/AlertsController.php
@@ -38,7 +38,7 @@ final class AlertsController extends Controller
             )),
             ArticleSection::basic('Community-building', 2, $this->render(
                 Listing::unordered([
-                    '<a href="'.$this->get('router')->generate('content-alerts').'">Sign up to our monthly community newsletter</a> for details on upcoming webinars, travel grant deadlines, interviews, and other efforts to connect and support especially early-career researchers in life sciences and biomedicine',
+                    '<a href="'.$this->get('router')->generate('content-alerts').'">Sign up to our monthly early-career researchers community newsletter</a> for details on upcoming webinars, new programmes, interviews, and other efforts to support positive research culture in life sciences and biomedicine',
                 ], 'bullet')
             )),
             ArticleSection::basic('eLife&apos;s Innovation Initiative and technology news', 2, $this->render(


### PR DESCRIPTION
Update additional newsletter links on the alert pages to point at the content-alert pages.