### PR TITLE
deploy to prod fix

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -21,7 +21,13 @@ elifePipeline {
             node('containers-jenkins-plugin') {
                 DockerImage.elifesciences(this, "journal", commit).pull().tag('latest').push()
             }
+            // ensure all nodes are registered
+            sh "${env.BUILDER_PATH}bldr 'deploy.load_balancer_register_all:${stackname}'"
+
+            // update buildvars in parallel, run highstate blue-green
             builderDeployRevision 'journal--prod', commit, 'blue-green'
+            
+            // run smoke tests in parallel
             builderSmokeTests 'journal--prod', '/srv/journal'
         }
     }


### PR DESCRIPTION
Jenkinsfile.prod, ensures all production nodes are registered with the load balancer before attempting to deploy.

addresses the problem we're seeing in issue #7092 where a previous failed deployment can't be solved by re-running the Jenkins job because the LB targets won't ever be healthy.