### PR TITLE
Refactor etoc subscribe and update code

### DIFF
--- a/src/Controller/ContentAlertsController.php
+++ b/src/Controller/ContentAlertsController.php
@@ -10,7 +10,6 @@ use eLife\Journal\Etoc\Technology;
 use eLife\Journal\Exception\EarlyResponse;
 use eLife\Journal\Form\Type\ContentAlertsType;
 use eLife\Journal\Form\Type\ContentAlertsUpdateRequestType;
-use eLife\Journal\Guzzle\CiviCrmClient;
 use eLife\Patterns\ViewModel\ArticleSection;
 use eLife\Patterns\ViewModel\Button;
 use eLife\Patterns\ViewModel\ButtonCollection;

--- a/src/Etoc/EarlyCareer.php
+++ b/src/Etoc/EarlyCareer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace eLife\Journal\Etoc;
+
+final class EarlyCareer extends NewsLetter
+{
+    const LABEL = 'early_career';
+    const GROUP = 'early_careers_news_317';
+    const GROUP_ID = 317;
+}
+

--- a/src/Etoc/EarlyCareer.php
+++ b/src/Etoc/EarlyCareer.php
@@ -8,4 +8,3 @@ final class EarlyCareer extends NewsLetter
     const GROUP = 'early_careers_news_317';
     const GROUP_ID = 317;
 }
-

--- a/src/Etoc/ElifeNewsletter.php
+++ b/src/Etoc/ElifeNewsletter.php
@@ -8,4 +8,3 @@ final class ElifeNewsletter extends NewsLetter
     const GROUP = 'eLife_bi_monthly_news_1032';
     const GROUP_ID = 1032;
 }
-

--- a/src/Etoc/ElifeNewsletter.php
+++ b/src/Etoc/ElifeNewsletter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace eLife\Journal\Etoc;
+
+final class ElifeNewsletter extends NewsLetter
+{
+    const LABEL = 'elife_newsletter';
+    const GROUP = 'eLife_bi_monthly_news_1032';
+    const GROUP_ID = 1032;
+}
+

--- a/src/Etoc/LatestArticles.php
+++ b/src/Etoc/LatestArticles.php
@@ -8,4 +8,3 @@ final class LatestArticles extends NewsLetter
     const GROUP = 'All_Content_53';
     const GROUP_ID = 53;
 }
-

--- a/src/Etoc/LatestArticles.php
+++ b/src/Etoc/LatestArticles.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace eLife\Journal\Etoc;
+
+final class LatestArticles extends NewsLetter
+{
+    const LABEL = 'latest_articles';
+    const GROUP = 'All_Content_53';
+    const GROUP_ID = 53;
+}
+

--- a/src/Etoc/NewsLetter.php
+++ b/src/Etoc/NewsLetter.php
@@ -19,15 +19,7 @@ abstract class NewsLetter
         return static::GROUP_ID;
     }
 
-    /**
-     * @return string|null
-     */
-    public function unsubscribeUrl()
-    {
-        return $this->unsubscribeUrl;
-    }
-
-    public function __toString()
+    public function __toString() : string
     {
         return $this->label();
     }

--- a/src/Etoc/NewsLetter.php
+++ b/src/Etoc/NewsLetter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eLife\Journal\Etoc;
+
+abstract class NewsLetter
+{
+    public function label() : string
+    {
+        return static::LABEL;
+    }
+
+    public function group() : string
+    {
+        return static::GROUP;
+    }
+
+    public function groupId() : int
+    {
+        return static::GROUP_ID;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function unsubscribeUrl()
+    {
+        return $this->unsubscribeUrl;
+    }
+
+    public function __toString()
+    {
+        return $this->label();
+    }
+}

--- a/src/Etoc/Subscription.php
+++ b/src/Etoc/Subscription.php
@@ -57,9 +57,9 @@ final class Subscription
             ElifeNewsletter::GROUP_ID => new ElifeNewsletter(),
         ];
 
-        $this->preferences = array_map(function ($preference) use ($groups) {
+        $this->preferences = array_values(array_map(function ($preference) use ($groups) {
             return $groups[$preference];
-        }, array_intersect(array_keys($groups), $preferences));
+        }, array_intersect(array_keys($groups), $preferences)));
     }
 
     public function id() : int

--- a/src/Etoc/Subscription.php
+++ b/src/Etoc/Subscription.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace eLife\Journal\Etoc;
+
+final class Subscription
+{
+    private $id;
+    private $optOut;
+    private $email;
+    private $firstName;
+    private $lastName;
+    private $preferences;
+    private $preferencesUrl;
+
+    public function __construct(
+        int $id,
+        bool $optOut,
+        string $email,
+        string $firstName,
+        string $lastName,
+        array $preferences,
+        string $preferencesUrl = null
+    )
+    {
+        $this->id = $id;
+        $this->optOut = $optOut;
+        $this->email = $email;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+        $this->setPreferences($preferences);
+        $this->preferencesUrl = $preferencesUrl;
+    }
+
+    /**
+     *
+     */
+    public static function getNewsletters(array $preferences) : array
+    {
+        $groups = [
+            LatestArticles::LABEL => new LatestArticles(),
+            EarlyCareer::LABEL => new EarlyCareer(),
+            Technology::LABEL => new Technology(),
+            ElifeNewsletter::LABEL => new ElifeNewsletter(),
+        ];
+
+        return array_map(function ($preference) use ($groups) {
+            return $groups[$preference];
+        }, array_intersect(array_keys($groups), $preferences));
+    }
+
+    private function setPreferences(array $preferences)
+    {
+        $groups = [
+            LatestArticles::GROUP_ID => new LatestArticles(),
+            EarlyCareer::GROUP_ID => new EarlyCareer(),
+            Technology::GROUP_ID => new Technology(),
+            ElifeNewsletter::GROUP_ID => new ElifeNewsletter(),
+        ];
+
+        $this->preferences = array_map(function ($preference) use ($groups) {
+            return $groups[$preference];
+        }, array_intersect(array_keys($groups), $preferences));
+    }
+
+    public function id() : int
+    {
+        return $this->id;
+    }
+
+    public function optOut() : bool
+    {
+        return $this->optOut;
+    }
+
+    public function email() : string
+    {
+        return $this->email;
+    }
+
+    public function firstName() : string
+    {
+        return $this->firstName;
+    }
+
+    public function lastName() : string
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @return NewsLetter[]
+     */
+    public function preferences() : array
+    {
+        return $this->preferences;
+    }
+
+    public function preferencesUrl() : ?string
+    {
+        return $this->preferencesUrl;
+    }
+
+    public function data() : array
+    {
+        $preferences = array_map(function (Newsletter $preference) {
+            return $preference->label();
+        }, $this->preferences());
+
+        return [
+            'contact_id' => $this->id(),
+            'email' => $this->email(),
+            'preferences' => $preferences,
+            'groups' => implode(',', $preferences),
+            'first_name' => $this->firstName(),
+            'last_name' => $this->lastName(),
+        ];
+    }
+}

--- a/src/Etoc/Technology.php
+++ b/src/Etoc/Technology.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace eLife\Journal\Etoc;
+
+final class Technology extends NewsLetter
+{
+    const LABEL = 'technology';
+    const GROUP = 'technology_news_435';
+    const GROUP_ID = 435;
+}
+

--- a/src/Etoc/Technology.php
+++ b/src/Etoc/Technology.php
@@ -8,4 +8,3 @@ final class Technology extends NewsLetter
     const GROUP = 'technology_news_435';
     const GROUP_ID = 435;
 }
-

--- a/src/Form/Type/ContentAlertsType.php
+++ b/src/Form/Type/ContentAlertsType.php
@@ -2,7 +2,10 @@
 
 namespace eLife\Journal\Form\Type;
 
-use eLife\Journal\Guzzle\CiviCrmClient;
+use eLife\Journal\Etoc\EarlyCareer;
+use eLife\Journal\Etoc\ElifeNewsletter;
+use eLife\Journal\Etoc\LatestArticles;
+use eLife\Journal\Etoc\Technology;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -67,10 +70,10 @@ final class ContentAlertsType extends AbstractType
     private function preferencesVariant(string $variant = null) : array
     {
         $preferences = [
-            'default' => ['The latest scientific articles published by eLife (twice weekly)' => CiviCrmClient::LABEL_LATEST_ARTICLES],
-            'early-career' => ['Early-career researchers newsletter (monthly)' => CiviCrmClient::LABEL_EARLY_CAREER],
-            'technology' => ['Technology and Innovation newsletter (every two months)' => CiviCrmClient::LABEL_TECHNOLOGY],
-            'elife-newsletter' => ['eLife newsletter (every two months)' => CiviCrmClient::LABEL_ELIFE_NEWSLETTER],
+            'default' => ['The latest scientific articles published by eLife (twice weekly)' => LatestArticles::LABEL],
+            'early-career' => ['Early-career researchers newsletter (monthly)' => EarlyCareer::LABEL],
+            'technology' => ['Technology and Innovation newsletter (every two months)' => Technology::LABEL],
+            'elife-newsletter' => ['eLife newsletter (every two months)' => ElifeNewsletter::LABEL],
         ];
         $main = [];
         $other = [];

--- a/src/Guzzle/CiviCrmClient.php
+++ b/src/Guzzle/CiviCrmClient.php
@@ -2,6 +2,8 @@
 
 namespace eLife\Journal\Guzzle;
 
+use eLife\Journal\Etoc\NewsLetter;
+use eLife\Journal\Etoc\Subscription;
 use eLife\Journal\Exception\CiviCrmResponseError;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -11,19 +13,6 @@ use function GuzzleHttp\Promise\all;
 
 final class CiviCrmClient implements CiviCrmClientInterface
 {
-    const LABEL_LATEST_ARTICLES = 'latest_articles';
-    const LABEL_EARLY_CAREER = 'early_career';
-    const LABEL_TECHNOLOGY = 'technology';
-    const LABEL_ELIFE_NEWSLETTER = 'elife_newsletter';
-    // Perhaps make the constants below configuration.
-    const GROUP_LATEST_ARTICLES = 'All_Content_53';
-    const GROUP_EARLY_CAREER = 'early_careers_news_317';
-    const GROUP_TECHNOLOGY = 'technology_news_435';
-    const GROUP_ELIFE_NEWSLETTER = 'eLife_bi_monthly_news_1032';
-    const GROUP_ID_LATEST_ARTICLES = 53;
-    const GROUP_ID_EARLY_CAREER = 317;
-    const GROUP_ID_TECHNOLOGY = 435;
-    const GROUP_ID_ELIFE_NEWSLETTER = 1032;
     // Assign all users to below group so we can easily identify them.
     const GROUP_JOURNAL_ETOC_SIGNUP = 'Journal_eToc_signup_1922';
     // Add the contact to the below group to trigger email with user preferences link.
@@ -155,18 +144,15 @@ final class CiviCrmClient implements CiviCrmClientInterface
                 $contactId = min(array_keys($values));
                 $contact = $values[$contactId];
 
-                $preferences = $this->preferenceGroupLabels(explode(',', $contact['groups']));
-
-                return [
-                    'contact_id' => (int) $contact['contact_id'],
-                    'opt_out' => ('1' === $contact['is_opt_out']),
-                    'email' => $contact['email'],
-                    'first_name' => $contact['first_name'],
-                    'last_name' => $contact['last_name'],
-                    'preferences' => $preferences,
-                    'groups' => implode(',', $preferences),
-                    'preferences_url' => $contact[self::FIELD_PREFERENCES_URL],
-                ];
+                return new Subscription(
+                    (int) $contact['contact_id'],
+                    ('1' === $contact['is_opt_out']),
+                    $contact['email'],
+                    $contact['first_name'],
+                    $contact['last_name'],
+                    explode(',', $contact['groups']),
+                    $contact[self::FIELD_PREFERENCES_URL]
+                );
             }
         });
     }
@@ -202,54 +188,15 @@ final class CiviCrmClient implements CiviCrmClientInterface
 
     private function preferenceGroups(array $preferences, $create = false) : array
     {
-        $clean = array_map(function ($preference) {
-            switch ($preference) {
-                case self::LABEL_LATEST_ARTICLES:
-                    return self::GROUP_LATEST_ARTICLES;
-                case self::LABEL_EARLY_CAREER:
-                    return self::GROUP_EARLY_CAREER;
-                case self::LABEL_TECHNOLOGY:
-                    return self::GROUP_TECHNOLOGY;
-                case self::LABEL_ELIFE_NEWSLETTER:
-                    return self::GROUP_ELIFE_NEWSLETTER;
-                default:
-                    return null;
-            }
-        }, array_intersect([
-            self::LABEL_LATEST_ARTICLES,
-            self::LABEL_EARLY_CAREER,
-            self::LABEL_TECHNOLOGY,
-            self::LABEL_ELIFE_NEWSLETTER,
-        ], $preferences));
+        $clean = array_map(function (NewsLetter $newsletter) {
+            return $newsletter->group();
+        }, $preferences);
 
         if ($create) {
             array_push($clean, self::GROUP_JOURNAL_ETOC_SIGNUP);
         }
 
         return array_values($clean);
-    }
-
-    private function preferenceGroupLabels(array $groupIds) : array
-    {
-        return array_values(array_map(function ($groupId) {
-            switch ($groupId) {
-                case self::GROUP_ID_LATEST_ARTICLES:
-                    return self::LABEL_LATEST_ARTICLES;
-                case self::GROUP_ID_EARLY_CAREER:
-                    return self::LABEL_EARLY_CAREER;
-                case self::GROUP_ID_TECHNOLOGY:
-                    return self::LABEL_TECHNOLOGY;
-                case self::GROUP_ID_ELIFE_NEWSLETTER:
-                    return self::LABEL_ELIFE_NEWSLETTER;
-                default:
-                    return null;
-            }
-        }, array_intersect([
-            self::GROUP_ID_LATEST_ARTICLES,
-            self::GROUP_ID_EARLY_CAREER,
-            self::GROUP_ID_TECHNOLOGY,
-            self::GROUP_ID_ELIFE_NEWSLETTER,
-        ], $groupIds)));
     }
 
     private function prepareRequest(string $method = 'GET', array $headers = []) : Request

--- a/test/Etoc/SubscriptionTest.php
+++ b/test/Etoc/SubscriptionTest.php
@@ -4,6 +4,7 @@ namespace test\eLife\Journal\Etoc;
 
 use eLife\Journal\Etoc\EarlyCareer;
 use eLife\Journal\Etoc\LatestArticles;
+use eLife\Journal\Etoc\NewsLetter;
 use eLife\Journal\Etoc\Subscription;
 use PHPUnit\Framework\TestCase;
 
@@ -71,5 +72,7 @@ final class SubscriptionTest extends TestCase
         $subscription = new Subscription(1, false, '', '', '', [$unknown1, LatestArticles::GROUP_ID, $unknown2, EarlyCareer::GROUP_ID]);
 
         $this->assertCount(2, $subscription->preferences());
+        $this->assertInstanceOf(NewsLetter::class, $subscription->preferences()[0]);
+        $this->assertInstanceOf(NewsLetter::class, $subscription->preferences()[1]);
     }
 }

--- a/test/Etoc/SubscriptionTest.php
+++ b/test/Etoc/SubscriptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace test\eLife\Journal\Etoc;
+
+use eLife\Journal\Etoc\EarlyCareer;
+use eLife\Journal\Etoc\LatestArticles;
+use eLife\Journal\Etoc\Subscription;
+use PHPUnit\Framework\TestCase;
+
+final class SubscriptionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_stores_a_subscription_profile()
+    {
+        $subscription = new Subscription(1, false, 'example@email.com', 'First', 'Last', [LatestArticles::GROUP_ID]);
+
+        $this->assertSame(1, $subscription->id());
+        $this->assertFalse($subscription->optOut());
+        $this->assertSame('example@email.com', $subscription->email());
+        $this->assertSame('First', $subscription->firstName());
+        $this->assertSame('Last', $subscription->lastName());
+        $this->assertEquals([new LatestArticles()], $subscription->preferences());
+    }
+
+    /**
+     * @test
+     */
+    public function it_may_have_a_preferences_url()
+    {
+        $with = new Subscription(1, false, 'example@email.com', '', '', [], 'http://localhost/content-alerts/foo');
+        $withOut = new Subscription(1, false, 'example@email.com', '', '', []);
+
+        $this->assertSame('http://localhost/content-alerts/foo', $with->preferencesUrl());
+        $this->assertNull($withOut->preferencesUrl());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_prepare_data_array_for_form()
+    {
+        $subscription = new Subscription(1, false, 'example@email.com', 'First', 'Last', [LatestArticles::GROUP_ID, EarlyCareer::GROUP_ID]);
+
+        $this->assertSame([
+            'contact_id' => 1,
+            'email' => 'example@email.com',
+            'preferences' => [
+                'latest_articles',
+                'early_career',
+            ],
+            'groups' => 'latest_articles,early_career',
+            'first_name' => 'First',
+            'last_name' => 'Last',
+        ], $subscription->data());
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_prepare_only_recognised_newsletter_preferences()
+    {
+        $unknown1 = 1;
+        $unknown2 = 999;
+
+        $subscription = new Subscription(1, false, '', '', '', [$unknown1, $unknown2]);
+
+        $this->assertCount(0, $subscription->preferences());
+
+        $subscription = new Subscription(1, false, '', '', '', [$unknown1, LatestArticles::GROUP_ID, $unknown2, EarlyCareer::GROUP_ID]);
+
+        $this->assertCount(2, $subscription->preferences());
+    }
+}

--- a/test/Guzzle/MockCiviCrmClient.php
+++ b/test/Guzzle/MockCiviCrmClient.php
@@ -2,7 +2,9 @@
 
 namespace test\eLife\Journal\Guzzle;
 
-use eLife\Journal\Guzzle\CiviCrmClient;
+use eLife\Journal\Etoc\EarlyCareer;
+use eLife\Journal\Etoc\LatestArticles;
+use eLife\Journal\Etoc\Subscription;
 use eLife\Journal\Guzzle\CiviCrmClientInterface;
 use GuzzleHttp\Promise\PromiseInterface;
 use function GuzzleHttp\Promise\promise_for;
@@ -48,7 +50,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
     }
 
     /**
-     * @return array|null
+     * @return Subscription|null
      */
     private function presetsCheckSubscription(string $identifier, $isPreferencesId = false)
     {
@@ -59,43 +61,36 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
         switch (true) {
             case '/content-alerts/green' === $identifier && $isPreferencesId:
             case 'green@example.com' === $identifier && !$isPreferencesId:
-                $preferences = [CiviCrmClient::LABEL_LATEST_ARTICLES];
-                return [
-                    'contact_id' => 12345,
-                    'opt_out' => false,
-                    'email' => 'green@example.com',
-                    'first_name' => 'Green',
-                    'last_name' => 'Example',
-                    'preferences' => $preferences,
-                    'groups' => implode(',', $preferences),
-                    CiviCrmClient::FIELD_PREFERENCES_URL => 'http://localhost/content-alerts/green',
-                ];
+                return new Subscription(
+                    12345,
+                    false,
+                    'green@example.com',
+                    'Green',
+                    'Example',
+                    [new LatestArticles()],
+                    'http://localhost/content-alerts/green'
+                );
             case '/content-alerts/amber' === $identifier && $isPreferencesId:
             case 'amber@example.com' === $identifier && !$isPreferencesId:
-                $preferences = [];
-                return [
-                    'contact_id' => 23456,
-                    'opt_out' => false,
-                    'email' => 'amber@example.com',
-                    'first_name' => 'Amber',
-                    'last_name' => 'Example',
-                    'preferences' => $preferences,
-                    'groups' => implode(',', $preferences),
-                    CiviCrmClient::FIELD_PREFERENCES_URL => '',
-                ];
+                return new Subscription(
+                    23456,
+                    false,
+                    'amber@example.com',
+                    'Amber',
+                    'Example',
+                    []
+                );
             case '/content-alerts/red' === $identifier && $isPreferencesId:
             case 'red@example.com' === $identifier && !$isPreferencesId:
-                $preferences = [CiviCrmClient::LABEL_LATEST_ARTICLES, CiviCrmClient::GROUP_EARLY_CAREER];
-                return [
-                    'contact_id' => 34567,
-                    'opt_out' => true,
-                    'email' => 'red@example.com',
-                    'first_name' => 'Red',
-                    'last_name' => 'Example',
-                    'preferences' => $preferences,
-                    'groups' => implode(',', $preferences),
-                    CiviCrmClient::FIELD_PREFERENCES_URL => 'http://localhost/content-alerts/red',
-                ];
+                return new Subscription(
+                    34567,
+                    true,
+                    'red@example.com',
+                    'Red',
+                    'Example',
+                    [new LatestArticles(), new EarlyCareer()],
+                    'http://localhost/content-alerts/red'
+                );
             default:
                 return null;
         }

--- a/test/Guzzle/MockCiviCrmClient.php
+++ b/test/Guzzle/MockCiviCrmClient.php
@@ -67,7 +67,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
                     'green@example.com',
                     'Green',
                     'Example',
-                    [new LatestArticles()],
+                    [LatestArticles::GROUP_ID],
                     'http://localhost/content-alerts/green'
                 );
             case '/content-alerts/amber' === $identifier && $isPreferencesId:
@@ -88,7 +88,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
                     'red@example.com',
                     'Red',
                     'Example',
-                    [new LatestArticles(), new EarlyCareer()],
+                    [LatestArticles::GROUP_ID, EarlyCareer::GROUP_ID],
                     'http://localhost/content-alerts/red'
                 );
             default:


### PR DESCRIPTION
In anticipate of supporting unsubscribing from individual newsletters, I found that CiviCrmClient was becoming burdened with configuration and sought an opportunity to unravel it. This should reduce the delta of the impending PR implementing the unsubscribe wokflow.