### PR TITLE
Adjust README to allow for successfully run of unit tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To run all unit tests as in `ci`:
 
 `docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci .ci/phpunit`
 
-To apply a single test:
+To run a single test:
 
 ```
 APP_ENV=ci docker-compose run app vendor/bin/phpunit --filter AboutControllerTest

--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ Regenerating critical CSS
 Running the tests
 -----------------
 
-`docker-compose run app vendor/bin/phpunit`
+To run all unit tests as in `ci`:
+
+`docker-compose -f docker-compose.yml -f docker-compose.ci.yml run ci .ci/phpunit`
+
+To apply a single test:
+
+```
+APP_ENV=ci docker-compose run app vendor/bin/phpunit --filter AboutControllerTest
+```
 
 Running Behat
 -------------

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,6 +2,9 @@ version: '3'
 
 services:
     composer:
+        build:
+            args:
+                composer_dev_arg:
         volumes:
             - ./composer.json:/app/composer.json
             - ./composer.lock:/app/composer.lock


### PR DESCRIPTION
This fixes an issue introduce in: https://github.com/elifesciences/journal/pull/1632

Without this a run of `phpunit` would not have worked locally following the README.