### PR TITLE
Updated elife/patterns to 0dc2368: Updated pattern-library to b49ef93: Possible fix for extra long urls

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1333,12 +1333,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "8d93982d827fc00361bf32534296620a82f063e3"
+                "reference": "0dc2368dd60e26f1724784a3b2b4fdc128822492"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/8d93982d827fc00361bf32534296620a82f063e3",
-                "reference": "8d93982d827fc00361bf32534296620a82f063e3",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/0dc2368dd60e26f1724784a3b2b4fdc128822492",
+                "reference": "0dc2368dd60e26f1724784a3b2b4fdc128822492",
                 "shasum": ""
             },
             "require": {
@@ -1375,7 +1375,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2022-08-30T09:47:13+00:00"
+            "time": "2022-09-05T12:02:42+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/612/display/redirect which resulted in this pull request.