### PR TITLE
Limit cover to 3 for carousel

### DIFF
--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -74,7 +74,7 @@ final class HomeController extends Controller
             ->getCurrent()
             ->map($this->willConvertTo(CarouselItem::class))
             ->then(Callback::emptyOr(function (Sequence $covers) {
-                return new Carousel($covers->toArray(), new ListHeading('Highlights', 'highlights'));
+                return new Carousel($covers->slice(0, 3)->toArray(), new ListHeading('Highlights', 'highlights'));
             }))
             ->otherwise($this->softFailure('Failed to load covers'));
 


### PR DESCRIPTION
In anticipation of an increase to 4 covers we need to ensure that only a maximum of 3 covers are brought into the carousel.