### PR TITLE
Updated elife/patterns to 3c76a40: Make summary optional because collection, article, and blog article can be null

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1333,12 +1333,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "29b890710b2734d3aa18e4f276d6bd74bf60d60f"
+                "reference": "3c76a40d1a91e0d45973adb7d40e5c65ef3bd03f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/29b890710b2734d3aa18e4f276d6bd74bf60d60f",
-                "reference": "29b890710b2734d3aa18e4f276d6bd74bf60d60f",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/3c76a40d1a91e0d45973adb7d40e5c65ef3bd03f",
+                "reference": "3c76a40d1a91e0d45973adb7d40e5c65ef3bd03f",
                 "shasum": ""
             },
             "require": {
@@ -1375,7 +1375,7 @@
                 "MIT"
             ],
             "description": "eLife patterns",
-            "time": "2022-09-29T13:09:43+00:00"
+            "time": "2022-10-03T11:31:48+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/622/display/redirect which resulted in this pull request.