### PR TITLE
Feature flagged About page text for announcement

### DIFF
--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -8,7 +8,8 @@
     {{ parent() }}
     <style>
         .prc-comms {
-            color: red;
+            background-color: #f5f7fa;
+            padding: 2em 4em;
         }
     </style>
 {% endblock %}

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -13,6 +13,20 @@
             font-family: "Noto Sans",Arial,Helvetica,sans-serif;
             font-size: calc((14 / 16) * 1rem);
             line-height: 1.7;
+            position: relative;
+        }
+
+        .prc-comms::before {
+            content: '';
+            width: calc((20 / 16) * 1em);
+            height: calc((20 / 16) * 1em);
+            display: block;
+            background-image: url('data:image/svg+xml;utf8,<svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>Information</title><path d="M10 0C4.5 0 0 4.5 0 10s4.5 10 10 10 10-4.5 10-10S15.5 0 10 0zm1 15H9V9h2v6zm0-8H9V5h2v2z" fill="%23177cc9" fill-rule="evenodd"/></svg>');
+            background-repeat: no-repeat;
+            background-size: contain;
+            position: absolute;
+            left: calc((20px + 0.5em));
+            top: calc(2em + 2px);
         }
     </style>
 {% endblock %}

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -19,7 +19,7 @@
     {% embed 'grid/content.html.twig' %}
 
         {% block main %}
-            {% if is_granted('FEATURE_BANANA') %}
+            {% if is_granted('FEATURE_PRC_COMMS') %}
                 <p>eLife's peer-review process is changing. From January 2023, eLife will no longer accept or reject articles for publication. Instead, eLife will publish every preprint sent for peer review, along with the reviews as a "Reviewed preprint". Editors will also provide an assessment in consultation with Reviewers that use a standardised format to summarise the strength of evidence supporting authors' claims and the preprint's potential impact.</p>
             {% endif %}
 

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -4,6 +4,15 @@
 
 {% block title %}{{ title }}{% if title != 'About' %} | About{% endif %}{% endblock %}
 
+{% block head %}
+    {{ parent() }}
+    <style>
+        .prc-comms {
+            color: red;
+        }
+    </style>
+{% endblock %}
+
 {% block body %}
 
     {{ render_pattern(contentHeader) }}
@@ -20,7 +29,7 @@
 
         {% block main %}
             {% if is_granted('FEATURE_PRC_COMMS') %}
-                <p>eLife's peer-review process is changing. From January 2023, eLife will no longer accept or reject articles for publication. Instead, eLife will publish every preprint sent for peer review, along with the reviews as a "Reviewed preprint". Editors will also provide an assessment in consultation with Reviewers that use a standardised format to summarise the strength of evidence supporting authors' claims and the preprint's potential impact.</p>
+                <p class="prc-comms">eLife's peer-review process is changing. From January 2023, eLife will no longer accept or reject articles for publication. Instead, eLife will publish every preprint sent for peer review, along with the reviews as a "Reviewed preprint". Editors will also provide an assessment in consultation with Reviewers that use a standardised format to summarise the strength of evidence supporting authors' claims and the preprint's potential impact.</p>
             {% endif %}
 
             {% for part in body %}

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -10,6 +10,9 @@
         .prc-comms {
             background-color: #f5f7fa;
             padding: 2em 4em;
+            font-family: "Noto Sans",Arial,Helvetica,sans-serif;
+            font-size: calc((14 / 16) * 1rem);
+            line-height: 1.7;
         }
     </style>
 {% endblock %}

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -20,7 +20,7 @@
 
         {% block main %}
             {% if is_granted('FEATURE_BANANA') %}
-                <div>some  text</div>
+                <p>eLife's peer-review process is changing. From January 2023, eLife will no longer accept or reject articles for publication. Instead, eLife will publish every preprint sent for peer review, along with the reviews as a "Reviewed preprint". Editors will also provide an assessment in consultation with Reviewers that use a standardised format to summarise the strength of evidence supporting authors' claims and the preprint's potential impact.</p>
             {% endif %}
 
             {% for part in body %}

--- a/app/Resources/views/about.html.twig
+++ b/app/Resources/views/about.html.twig
@@ -19,6 +19,9 @@
     {% embed 'grid/content.html.twig' %}
 
         {% block main %}
+            {% if is_granted('FEATURE_BANANA') %}
+                <div>some  text</div>
+            {% endif %}
 
             {% for part in body %}
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,7 +10,7 @@ parameters:
     api_timeout_slow: 10
     honeypot_field: email_address
     mustache_stat_props: [size, mtime]
-    feature_banana: false
+    feature_prc_comms: false
 
 bobthecow_mustache:
     globals:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,6 +10,7 @@ parameters:
     api_timeout_slow: 10
     honeypot_field: email_address
     mustache_stat_props: [size, mtime]
+    feature_banana: false
 
 bobthecow_mustache:
     globals:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -3,7 +3,7 @@ imports:
   - resource: services_dev.yml
 
 parameters:
-  feature_banana: true
+  feature_prc_comms: true
 
 csa_guzzle:
     profiler:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -2,6 +2,9 @@ imports:
   - resource: config.yml
   - resource: services_dev.yml
 
+parameters:
+  feature_banana: true
+
 csa_guzzle:
     profiler:
         enabled: true

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -370,12 +370,12 @@ services:
         tags:
           - name: security.voter
 
-    elife.journal.security.voter.feature.banana:
+    elife.journal.security.voter.feature.prc_comms:
         class: eLife\Journal\Security\Voter\FixedVoter
         public: false
         arguments:
-          - FEATURE_BANANA
-          - '%feature_banana%'
+          - FEATURE_PRC_COMMS
+          - '%feature_prc_comms%'
         tags:
           - name: security.voter
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -370,6 +370,15 @@ services:
         tags:
           - name: security.voter
 
+    elife.journal.security.voter.feature.banana:
+        class: eLife\Journal\Security\Voter\FixedVoter
+        public: false
+        arguments:
+          - FEATURE_BANANA
+          - '%feature_banana%'
+        tags:
+          - name: security.voter
+
     elife.journal.templating.promise_aware:
         class: eLife\Journal\Templating\PromiseAwareEngine
         decorates: templating


### PR DESCRIPTION
Added feature flagged (only available on the dev environment) ability to have the top of the About pages, except the people page, contain the PRC-related announcement text.

Note that it is expected that a link will need to be added to an as yet unwritten post before the feature flag is removed.