### PR TITLE
feat(README.md): add demo information for Digital Litmus

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,5 @@ Unsubscribe/optout interface:
 - Visit http://localhost:8080/content-alerts/optout/red to trigger something went wrong scenario
 
 To work on the integration with CiviCRM you will have to set the environment variable `APP_ENV=prod`. And also adjust the values in `.docker/parameters.yml` for `crm_api_key`, `crm_api_site_key`, `google_api_client.refresh_token` and `google_api_client.optout_unsubscribe_spreadsheet_id` to be the same as in production.
+
+DEMO FOR DIGITAL LITMUS

--- a/src/Guzzle/MockCiviCrmClient.php
+++ b/src/Guzzle/MockCiviCrmClient.php
@@ -3,6 +3,7 @@
 namespace eLife\Journal\Guzzle;
 
 use eLife\CiviContacts\Etoc\EarlyCareer;
+use eLife\CiviContacts\Etoc\ElifeNewsletter;
 use eLife\CiviContacts\Etoc\LatestArticles;
 use eLife\CiviContacts\Etoc\Newsletter;
 use eLife\CiviContacts\Etoc\Subscription;
@@ -93,7 +94,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
                     'green@example.com',
                     'Green',
                     'Example',
-                    [LatestArticles::GROUP_ID],
+                    [LatestArticles::GROUP_ID, ElifeNewsletter::GROUP_ID],
                     'http://localhost/content-alerts/green'
                 );
             case '/content-alerts/amber' === $identifier && !$isEmail:
@@ -106,7 +107,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
                     'amber@example.com',
                     'Amber',
                     'Example',
-                    []
+                    [EarlyCareer::GROUP_ID]
                 );
             case '/content-alerts/red' === $identifier && !$isEmail:
             case strpos($identifier, '/content-alerts/unsubscribe/red') !== false && !$isEmail:

--- a/src/Guzzle/MockCiviCrmClient.php
+++ b/src/Guzzle/MockCiviCrmClient.php
@@ -3,7 +3,6 @@
 namespace eLife\Journal\Guzzle;
 
 use eLife\CiviContacts\Etoc\EarlyCareer;
-use eLife\CiviContacts\Etoc\ElifeNewsletter;
 use eLife\CiviContacts\Etoc\LatestArticles;
 use eLife\CiviContacts\Etoc\Newsletter;
 use eLife\CiviContacts\Etoc\Subscription;
@@ -94,7 +93,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
                     'green@example.com',
                     'Green',
                     'Example',
-                    [LatestArticles::GROUP_ID, ElifeNewsletter::GROUP_ID],
+                    [LatestArticles::GROUP_ID],
                     'http://localhost/content-alerts/green'
                 );
             case '/content-alerts/amber' === $identifier && !$isEmail:
@@ -107,7 +106,7 @@ final class MockCiviCrmClient implements CiviCrmClientInterface
                     'amber@example.com',
                     'Amber',
                     'Example',
-                    [EarlyCareer::GROUP_ID]
+                    []
                 );
             case '/content-alerts/red' === $identifier && !$isEmail:
             case strpos($identifier, '/content-alerts/unsubscribe/red') !== false && !$isEmail:


### PR DESCRIPTION
Keep this around for demo purpose for the Digital Litmus team to demonstrate the user journeys for content alert sign up and preference management.