### PR TITLE
Better AppleSilicon support for building support images

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,3 @@ API_URL=http://api_dummy:8080
 API_URL_SEARCH_PAGE=http://api_dummy:8080
 API_URL_PUBLIC=http://localhost:8081
 API_KEY=public
-# If `docker-compose up --build` fails on your local Apple Silicon machine, set SKIP_IMAGE_BANNERS to yes.
-# This will not display any image banners in the page headers in the browser, but it will allow you to perform local testing.
-SKIP_IMAGE_BANNERS=no

--- a/Dockerfile.assets_builder
+++ b/Dockerfile.assets_builder
@@ -14,6 +14,4 @@ COPY assets/images/ assets/images/
 COPY gulpfile.js ./
 COPY --from=composer /app/vendor/elife/patterns/resources/assets/ vendor/elife/patterns/resources/assets/
 
-ARG skip_image_banners
-ENV SKIP_IMAGE_BANNERS=${skip_image_banners}
 RUN node_modules/.bin/gulp assets

--- a/Dockerfile.composer
+++ b/Dockerfile.composer
@@ -1,4 +1,4 @@
-FROM composer:1.6.4
+FROM composer:1.10
 
 ARG composer_dev_arg
 

--- a/Dockerfile.npm
+++ b/Dockerfile.npm
@@ -4,9 +4,14 @@ FROM node:${node_version} as npm
 RUN apt-get update && apt-get install --no-install-recommends -y \
     nasm \
     libvips-dev \
+    && wget http://ftp.de.debian.org/debian/pool/main/p/phantomjs/phantomjs_2.1.1+dfsg-2_$(dpkg --print-architecture).deb \
+    && apt-get install -y ./phantomjs_2.1.1+dfsg-2_$(dpkg --print-architecture).deb \
+    && rm ./phantomjs_2.1.1+dfsg-2_$(dpkg --print-architecture).deb \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
+# Fix for ARM64
+ENV CFLAGS="-DPNG_ARM_NEON_OPT=0"
 COPY npm-shrinkwrap.json \
     package.json \
     /app/

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,5 @@
 ARG image_tag=latest
-FROM elifesciences/journal:${image_tag} AS app
+FROM --platform="linux/amd64" elifesciences/journal:${image_tag} AS app
 FROM nginx:1.25.1-alpine
 
 COPY .docker/nginx-default.conf /etc/nginx/conf.d/default.conf

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,6 @@ version: '3'
 
 services:
     composer:
-        platform: linux/amd64
         build:
             args:
                 composer_dev_arg:
@@ -11,13 +10,11 @@ services:
             - ./composer.lock:/app/composer.lock
             - ./vendor:/app/vendor
     npm:
-        platform: linux/amd64
         volumes:
             - ./npm-shrinkwrap.json:/npm-shrinkwrap.json
             - ./package.json:/package.json
             - node_modules:/node_modules
     assets_builder:
-        platform: linux/amd64
         volumes:
             - ./assets/images:/assets/images
             - assets:/web
@@ -25,7 +22,6 @@ services:
             - node_modules:/node_modules
             - ./gulpfile.js:/gulpfile.js
     app:
-        platform: linux/amd64
         environment:
             - APP_ENV=${APP_ENV}
         volumes:
@@ -36,11 +32,9 @@ services:
             - critical_css:/srv/journal/build/critical-css
             - ./vendor:/srv/journal/vendor
     web:
-        platform: linux/amd64
         volumes:
             - assets:/srv/journal/web
     critical_css:
-        platform: linux/amd64
         volumes:
             - critical_css:/build/critical-css
             - node_modules:/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
             args:
                 image_tag: ${IMAGE_TAG}
                 node_version: ${NODE_VERSION}
-                skip_image_banners: ${SKIP_IMAGE_BANNERS:-no}
         image: elifesciences/journal_assets_builder:${IMAGE_TAG}
         depends_on:
             - composer

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,10 +101,6 @@ gulp.task('images:banners', () => {
         .pipe(gulp.dest('./build/assets/images/banners'));
 });
 
-gulp.task('images:banners:skipped', () => {
-    return Promise.resolve('');
-});
-
 gulp.task('images:social', () => {
     return gulp.src('./assets/images/social/*.png')
         .pipe(responsive({
@@ -207,9 +203,7 @@ gulp.task('images:svgs', () => {
         .pipe(gulp.dest('./build/assets/images'));
 });
 
-const imageBannersTaskName = process.env.SKIP_IMAGE_BANNERS === 'yes' ? 'images:banners:skipped' : 'images:banners';
-
-gulp.task('images', gulp.series('images:clean', imageBannersTaskName, 'images:social', 'images:investors', 'images:svgs', 'images:logos', () => {
+gulp.task('images', gulp.series('images:clean', 'images:banners', 'images:social', 'images:investors', 'images:svgs', 'images:logos', () => {
     return gulp.src('./build/assets/images/**/*')
         .pipe(imageMin([
             imageMinMozjpeg({


### PR DESCRIPTION
This branch fixes issues with running native ARM images to build journal containers, and reverts most of the workarounds from https://github.com/elifesciences/journal/commit/d6c0984506915fbd0e9e4ce76f34419b7779b75d

The benefits of this are:
- banner images are there
- it will be quite a lot faster.

Todo:
- [x] Test on another AppleSilion macos docker setup (@LinaKind ?)
- [x] Test on intel macos docker setup (@ali-tm-amin, ~@davidcmoulton ? @discodavey ?~)
- [x] Test on intel linux docker setup (done by @will-byrne)
- [x] Test on CI setup (older docker)

Related https://github.com/elifesciences/issues/issues/8976