### PR TITLE
Allow `make test` to run one test only, or a subset of tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ clean:
 	$(DOCKER_COMPOSE) down --volumes --remove-orphans
 
 test:
-	APP_ENV=ci $(DOCKER_COMPOSE) run --rm app vendor/bin/phpunit
+	APP_ENV=ci $(DOCKER_COMPOSE) run --rm app vendor/bin/phpunit --filter Test
 	APP_ENV=ci $(DOCKER_COMPOSE) down --volumes
 
 feature-test:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 DOCKER_COMPOSE = docker-compose
+TEST = Test
 
 .PHONY: build dev stop clean test feature-test lint check
 
@@ -15,7 +16,7 @@ clean:
 	$(DOCKER_COMPOSE) down --volumes --remove-orphans
 
 test:
-	APP_ENV=ci $(DOCKER_COMPOSE) run --rm app vendor/bin/phpunit --filter Test
+	APP_ENV=ci $(DOCKER_COMPOSE) run --rm app vendor/bin/phpunit --filter $(TEST)
 	APP_ENV=ci $(DOCKER_COMPOSE) down --volumes
 
 feature-test:


### PR DESCRIPTION
@discodavey for your information. This is a tooling update to run one PHPUnit test at a time.