### PR TITLE
Upgrade to composer 2 lts

### DIFF
--- a/Dockerfile.composer
+++ b/Dockerfile.composer
@@ -1,4 +1,4 @@
-FROM composer:1.10
+FROM composer:2.2.24
 
 ARG composer_dev_arg
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ When using Windows to bypass the main errors we recommend to follow the next :
 
       How to install : [Guide 1](https://5balloons.info/how-to-install-php-v-7-3-on-ubuntu-20-04) / [Guide 2](https://computingforgeeks.com/how-to-install-php-ubuntu-debian/)
 
-    * `Composer version 1.10.26 2022-04-13 16:39:56`
+    * `Composer version 2.2`
 
-      How to install : [Step 1](https://getcomposer.org/download/) & [Step 2](https://serverpilot.io/docs/how-to-downgrade-to-composer-version-1/)
+      How to install : [Step 1](https://getcomposer.org/download/)
 </details>
 
 Docker Installation - Running the site locally


### PR DESCRIPTION
https://blog.packagist.com/deprecating-composer-1-support/ (from 2021) explains that 
> The update rate for new versions will be reduced from every-minute currently to once every 15 minutes. This means new releases will take a few minutes longer to be available for installation with Composer 1.x.

It's possible this is what causes [failures while waiting for a new version of `elife/patterns` to be available](https://alfred.elifesciences.org/job/dependencies/job/dependencies-journal-update-patterns-php/).

Furthermore, https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/ states
> February 1st, 2025: Composer 1.x metadata will become read-only. No new packages or new versions will be visible for Composer 1.x users after this date.

According to https://getcomposer.org/doc/00-intro.md:
> Composer in its latest version requires PHP 7.2.5 to run. A long-term-support version (2.2.x) still offers support for PHP 5.3.2+ in case you are stuck with a legacy PHP version. A few sensitive php settings and compile flags are also required, but when using the installer you will be warned about any incompatibilities.

meaning we can use `2.2` as the long term support version, but not the latest `2.8`. `2.3` indeed [requires a newer PHP version](https://github.com/composer/composer/issues/10340).