### PR TITLE
Remove deprecated SYMFONY__* magic environment variables

### DIFF
--- a/.docker/parameters.yml
+++ b/.docker/parameters.yml
@@ -1,5 +1,8 @@
 parameters:
-    api_key: public
+    api_url: "%env(API_URL)%"
+    api_url_search_page: "%env(API_URL_SEARCH_PAGE)%"
+    api_url_public: "%env(API_URL_PUBLIC)%"
+    api_key: "%env(API_KEY)%"
     side_by_side_view_url: https://lens.elifesciences.org/
     secret: ThisTokenIsNotSoSecretChangeIt
     session_name: journal

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -33,6 +33,10 @@ services:
             - fixtures:/srv/journal/var/fixtures
         environment:
             - APP_ENV=ci
+            - API_URL=${API_URL}
+            - API_URL_SEARCH_PAGE=${API_URL_SEARCH_PAGE:-${API_URL}}
+            - API_URL_PUBLIC=${API_URL_PUBLIC}
+            - API_KEY=${API_KEY}
         depends_on:
             - composer-dev
             - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,10 +36,10 @@ services:
                 image_tag: ${IMAGE_TAG}
                 php_version: ${PHP_VERSION}
         environment:
-            - SYMFONY__API_URL=${API_URL}
-            - SYMFONY__API_URL_SEARCH_PAGE=${API_URL_SEARCH_PAGE:-${API_URL}}
-            - SYMFONY__API_URL_PUBLIC=${API_URL_PUBLIC}
-            - SYMFONY__API_KEY=${API_KEY}
+            - API_URL=${API_URL}
+            - API_URL_SEARCH_PAGE=${API_URL_SEARCH_PAGE:-${API_URL}}
+            - API_URL_PUBLIC=${API_URL_PUBLIC}
+            - API_KEY=${API_KEY}
         image: elifesciences/journal:${IMAGE_TAG}
         volumes:
             - ./.docker/parameters.yml:/srv/journal/app/config/parameters.yml


### PR DESCRIPTION
Following https://symfony.com/doc/current/configuration.html syntax to explicitly interpolate into configuration files rather than relying on the magic behavior that parses environment variables starting with SYMFONY__*

This was shown in the PHPUnit report, when running any single test via `make test`:
```
    1x: The support of special environment variables that start with SYMFONY__ (such as "SYMFONY__API_URL_SEARCH_PAGE") is deprecated as of 3.3 and will be removed in 4.0. Use the %env()% syntax instead to get the value of environment variables in configuration files.
    1x in BrowseControllerTest::it_shows_reviewed_preprints_on_results from test\eLife\Journal\Controller
```

Tested `make prod` and `make dev` locally, and a full `make test`.