### PR TITLE
Upgrading MathJax to v4.1

### DIFF
--- a/.env
+++ b/.env
@@ -12,3 +12,4 @@ JOURNAL_API_DUMMY_PORT=8081
 API_URL=http://api_dummy:8080
 API_URL_PUBLIC=http://localhost:8081
 API_KEY=public
+

--- a/.github/workflows/previews.yaml
+++ b/.github/workflows/previews.yaml
@@ -30,6 +30,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build container image
         run: |
+          docker compose -f 'docker-compose.yml' -f 'docker-compose.ci.yml' build composer composer-dev npm
+          docker compose -f 'docker-compose.yml' -f 'docker-compose.ci.yml' build assets_builder
+          docker compose -f 'docker-compose.yml' -f 'docker-compose.ci.yml' build app
           docker compose -f 'docker-compose.yml' -f 'docker-compose.ci.yml' build
           docker image tag elifesciences/journal:develop ${CONTAINER_REPO}:${CONTAINER_TAG}
       - name: Push container image

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_COMPOSE = docker-compose
 TEST = test/
-BRANCH = master
+BRANCH = update-mathjax-version
 
 .PHONY: build dev prod stop clean test feature-test lint lint-fix check update-patterns
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_COMPOSE = docker-compose
 TEST = test/
-BRANCH = update-mathjax-version
+BRANCH = master
 
 .PHONY: build dev prod stop clean test feature-test lint lint-fix check update-patterns
 

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -58,6 +58,8 @@ nelmio_security:
               - 'wss://*.hotjar.com'
               - unsafe-eval
               - unsafe-inline
+            worker-src:
+              - 'blob:'
     forced_ssl:
         whitelist:
           - ^/ # Hack to disable redirect.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "elife/api-client": "^1.0@dev",
         "elife/api-sdk": "dev-master",
         "elife/civi-contacts": "dev-master",
-        "elife/patterns": "dev-master",
+        "elife/patterns": "dev-update-mathjax-version",
         "fabpot/goutte": "^3.2",
         "fig/link-util": "^1.0",
         "firebase/php-jwt": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1378,12 +1378,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "bfa747f3988570f01b7b792c8911b077ee32fd5a"
+                "reference": "e06f8b6bc3eb587da3f5d6e26f1c4d9b0e5f8c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/bfa747f3988570f01b7b792c8911b077ee32fd5a",
-                "reference": "bfa747f3988570f01b7b792c8911b077ee32fd5a",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/e06f8b6bc3eb587da3f5d6e26f1c4d9b0e5f8c65",
+                "reference": "e06f8b6bc3eb587da3f5d6e26f1c4d9b0e5f8c65",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-05-19T10:01:37+00:00"
+            "time": "2026-05-20T09:54:13+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/composer.lock
+++ b/composer.lock
@@ -1378,12 +1378,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "a751afe8571da1257bb47393f52b549156d1f328"
+                "reference": "fcb5dc03b64a8dd931f3a4aaa2babf6d11743a67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/a751afe8571da1257bb47393f52b549156d1f328",
-                "reference": "a751afe8571da1257bb47393f52b549156d1f328",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/fcb5dc03b64a8dd931f3a4aaa2babf6d11743a67",
+                "reference": "fcb5dc03b64a8dd931f3a4aaa2babf6d11743a67",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-05-20T10:09:44+00:00"
+            "time": "2026-05-20T11:03:31+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e018f07a119b7e0d69b312bfcf22a99",
+    "content-hash": "6fb9eb2e51f65cea9c00c12c0b0ba057",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1374,16 +1374,16 @@
         },
         {
             "name": "elife/patterns",
-            "version": "dev-master",
+            "version": "dev-update-mathjax-version",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "e4fb364afade35d56451a0491ed66dee394669dc"
+                "reference": "ba5afaa4e17c92efc9e344b7a91964cf1c1b99cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/e4fb364afade35d56451a0491ed66dee394669dc",
-                "reference": "e4fb364afade35d56451a0491ed66dee394669dc",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/ba5afaa4e17c92efc9e344b7a91964cf1c1b99cb",
+                "reference": "ba5afaa4e17c92efc9e344b7a91964cf1c1b99cb",
                 "shasum": ""
             },
             "require": {
@@ -1406,7 +1406,6 @@
             "suggest": {
                 "twig/twig": "^2.0, to use PatternExtension"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "files": [
@@ -1422,9 +1421,9 @@
             ],
             "description": "eLife patterns",
             "support": {
-                "source": "https://github.com/elifesciences/patterns-php/tree/master"
+                "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-04-21T17:26:24+00:00"
+            "time": "2026-05-05T13:45:38+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/composer.lock
+++ b/composer.lock
@@ -1378,12 +1378,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "c8d62fb28eb5a77b14486747a2d23469a8bd5694"
+                "reference": "bfa747f3988570f01b7b792c8911b077ee32fd5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/c8d62fb28eb5a77b14486747a2d23469a8bd5694",
-                "reference": "c8d62fb28eb5a77b14486747a2d23469a8bd5694",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/bfa747f3988570f01b7b792c8911b077ee32fd5a",
+                "reference": "bfa747f3988570f01b7b792c8911b077ee32fd5a",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-05-13T14:48:17+00:00"
+            "time": "2026-05-19T10:01:37+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/composer.lock
+++ b/composer.lock
@@ -1378,12 +1378,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "ba5afaa4e17c92efc9e344b7a91964cf1c1b99cb"
+                "reference": "c8d62fb28eb5a77b14486747a2d23469a8bd5694"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/ba5afaa4e17c92efc9e344b7a91964cf1c1b99cb",
-                "reference": "ba5afaa4e17c92efc9e344b7a91964cf1c1b99cb",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/c8d62fb28eb5a77b14486747a2d23469a8bd5694",
+                "reference": "c8d62fb28eb5a77b14486747a2d23469a8bd5694",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-05-05T13:45:38+00:00"
+            "time": "2026-05-13T14:48:17+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/composer.lock
+++ b/composer.lock
@@ -1378,12 +1378,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "fcb5dc03b64a8dd931f3a4aaa2babf6d11743a67"
+                "reference": "461b8cba6009949847e94f3487c4c8dc0aa52be1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/fcb5dc03b64a8dd931f3a4aaa2babf6d11743a67",
-                "reference": "fcb5dc03b64a8dd931f3a4aaa2babf6d11743a67",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/461b8cba6009949847e94f3487c4c8dc0aa52be1",
+                "reference": "461b8cba6009949847e94f3487c4c8dc0aa52be1",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-05-20T11:03:31+00:00"
+            "time": "2026-05-20T14:07:28+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/composer.lock
+++ b/composer.lock
@@ -1378,12 +1378,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/patterns-php.git",
-                "reference": "e06f8b6bc3eb587da3f5d6e26f1c4d9b0e5f8c65"
+                "reference": "a751afe8571da1257bb47393f52b549156d1f328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/e06f8b6bc3eb587da3f5d6e26f1c4d9b0e5f8c65",
-                "reference": "e06f8b6bc3eb587da3f5d6e26f1c4d9b0e5f8c65",
+                "url": "https://api.github.com/repos/elifesciences/patterns-php/zipball/a751afe8571da1257bb47393f52b549156d1f328",
+                "reference": "a751afe8571da1257bb47393f52b549156d1f328",
                 "shasum": ""
             },
             "require": {
@@ -1423,7 +1423,7 @@
             "support": {
                 "source": "https://github.com/elifesciences/patterns-php/tree/update-mathjax-version"
             },
-            "time": "2026-05-20T09:54:13+00:00"
+            "time": "2026-05-20T10:09:44+00:00"
         },
         {
             "name": "fabpot/goutte",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,7 +17,7 @@ services:
     assets_builder:
         volumes:
             #
-#            - ../patterns-php/resources/assets:/vendor/elife/patterns/resources/assets
+            - ../patterns-php/resources/assets:/vendor/elife/patterns/resources/assets
 
             - ./assets/images:/assets/images
             - assets:/web
@@ -45,7 +45,7 @@ services:
             - build:/srv/journal/build
             - critical_css:/srv/journal/build/critical-css
 
-            - ../api-sdk-php:/srv/journal/vendor/elife/api-sdk
+#            - ../api-sdk-php:/srv/journal/vendor/elife/api-sdk
             - ../patterns-php:/srv/journal/vendor/elife/patterns
     web:
         volumes:


### PR DESCRIPTION
Journal runs MathJax v2.7.1 which is outdated. This PR updated MathJax to v4.1 and does a couple of modifications to ensure compatibility for the equations written for the previous MathJax versions. 